### PR TITLE
test/profile: Criacao dos testes unitarios

### DIFF
--- a/back-end/src/profile/profile.controller.spec.ts
+++ b/back-end/src/profile/profile.controller.spec.ts
@@ -1,18 +1,86 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { ProfileDto } from './profile.dto';
 
 describe('ProfileController', () => {
   let controller: ProfileController;
+  let service: ProfileService;
+
+  const mockProfileService = {
+    getProfile: jest.fn(),
+    updateProfile: jest.fn(),
+    deleteProfile: jest.fn(),
+  };
+
+  const mockUser = {
+    id: 'user-123',
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProfileController],
+      providers: [
+        {
+          provide: ProfileService,
+          useValue: mockProfileService,
+        },
+      ],
     }).compile();
 
     controller = module.get<ProfileController>(ProfileController);
+    service = module.get<ProfileService>(ProfileService);
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUserProfile', () => {
+    it('should return the user profile', async () => {
+      const mockProfile = {
+        name: 'João',
+        userName: 'joaosilva',
+        email: 'joao@email.com',
+      };
+
+      mockProfileService.getProfile.mockResolvedValue(mockProfile);
+
+      const result = await controller.getUserProfile({ user: mockUser });
+
+      expect(service.getProfile).toHaveBeenCalledWith('user-123');
+      expect(result).toEqual(mockProfile);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('should update the user profile and return a success message', async () => {
+      const dto: ProfileDto = {
+        name: 'João Atualizado',
+        userName: 'joaoupdated',
+        email: 'joao@novo.com',
+      };
+
+      mockProfileService.updateProfile.mockResolvedValue(dto);
+
+      const result = await controller.updateProfile({ user: mockUser }, dto);
+
+      expect(service.updateProfile).toHaveBeenCalledWith('user-123', dto);
+      expect(result).toEqual({
+        message: 'Perfil atualizado com sucesso.',
+        data: dto,
+      });
+    });
+  });
+
+  describe('deleteProfile', () => {
+    it('should delete the user profile and return a success message', async () => {
+      mockProfileService.deleteProfile.mockResolvedValue({});
+
+      const result = await controller.deleteProfile({ user: mockUser });
+
+      expect(service.deleteProfile).toHaveBeenCalledWith('user-123');
+      expect(result).toEqual({ message: 'Conta deletada com sucesso.' });
+    });
   });
 });

--- a/back-end/src/profile/profile.controller.ts
+++ b/back-end/src/profile/profile.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, UseGuards, Put, Delete } from '@nestjs/common';
 import { Request } from '@nestjs/common';
 import { ProfileService } from './profile.service';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { JwtAuthGuard } from 'src/guards/jwt.guard';
+import { JwtAuthGuard } from '../guards/jwt.guard';
 import { ProfileDto } from './profile.dto';
 
 @ApiTags('Perfil de usuário')

--- a/back-end/src/profile/profile.service.spec.ts
+++ b/back-end/src/profile/profile.service.spec.ts
@@ -1,18 +1,117 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ProfileService } from './profile.service';
+import { PrismaService } from '../services/prisma.service';
+import { ProfileDto } from './profile.dto';
 
 describe('ProfileService', () => {
   let service: ProfileService;
+  let prisma: PrismaService;
+
+  const mockPrisma = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ProfileService],
+      providers: [
+        ProfileService,
+        {
+          provide: PrismaService,
+          useValue: mockPrisma,
+        },
+      ],
     }).compile();
 
     service = module.get<ProfileService>(ProfileService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getProfile', () => {
+    it('should return the user profile', async () => {
+      const mockUser = {
+        id: '1',
+        name: 'João',
+        userName: 'joao123',
+        email: 'joao@email.com',
+      };
+
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+      const result = await service.getProfile('1');
+      expect(result).toEqual({
+        name: mockUser.name,
+        userName: mockUser.userName,
+        email: mockUser.email,
+      });
+    });
+
+    it('should throw error if user not found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getProfile('1')).rejects.toThrow(
+        'Usuário não encontrado',
+      );
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('must update and return the user profile', async () => {
+      const dto: ProfileDto = {
+        name: 'Novo Nome',
+        userName: 'novoUser',
+        email: 'novo@email.com',
+      };
+
+      const updatedUser = { id: '1', ...dto };
+
+      mockPrisma.user.update.mockResolvedValue(updatedUser);
+
+      const result = await service.updateProfile('1', dto);
+      expect(result).toEqual(updatedUser);
+    });
+
+    it('should throw error if update fails', async () => {
+      mockPrisma.user.update.mockResolvedValue(null);
+
+      await expect(
+        service.updateProfile('1', {
+          name: 'Test',
+          userName: 'testuser',
+          email: 'test@email.com',
+        }),
+      ).rejects.toThrow('Erro ao atualizar o perfil');
+    });
+  });
+
+  describe('deleteProfile', () => {
+    it('must delete and return the deleted profile', async () => {
+      const deletedUser = {
+        id: '1',
+        name: 'Deletado',
+        userName: 'deletado',
+        email: 'deletado@email.com',
+      };
+
+      mockPrisma.user.delete.mockResolvedValue(deletedUser);
+
+      const result = await service.deleteProfile('1');
+      expect(result).toEqual(deletedUser);
+    });
+
+    it('should throw error if deletion fails', async () => {
+      mockPrisma.user.delete.mockResolvedValue(null);
+
+      await expect(service.deleteProfile('1')).rejects.toThrow(
+        'Erro ao deletar o perfil',
+      );
+    });
   });
 });


### PR DESCRIPTION
### Criação dos testes unitários para o módulo profile: profile.service.spec.ts e profile.controller.spec.ts.

**profile.service.spec.ts**
Testar a lógica interna da classe ProfileService, que se comunica com o banco via PrismaService.

Testes escritos para:
- getProfile: retorna os dados do usuário e lança erro se não encontrar.
- updateProfile: atualiza o usuário e lança erro se falhar.
- deleteProfile: deleta o usuário e lança erro se falhar.

**profile.controller.spec.ts**
Testar os endpoints do controller ProfileController, garantindo que eles:

- Chamem corretamente os métodos do ProfileService.
- Retornem as respostas esperadas para cada rota (GET, PUT, DELETE).

Testes escritos para:
- getUserProfile: verifica se o perfil retornado é o esperado.
- updateProfile: verifica se o perfil é atualizado corretamente e retorna mensagem com os dados.
- deleteProfile: verifica se o método de exclusão é chamado e retorna a mensagem correta.

