### PR TITLE
test(auth): Criando testes para o service e controller do modulo auth

### DIFF
--- a/back-end/jest.config.ts
+++ b/back-end/jest.config.ts
@@ -1,13 +1,17 @@
 import { Config } from 'jest';
+import { pathsToModuleNameMapper } from 'ts-jest';
+import { compilerOptions } from './tsconfig.json';
 
 const config: Config = {
   moduleFileExtensions: ['js', 'json', 'ts'],
   rootDir: '.',
-  testMatch: ['**/test/**/*.spec.ts'], // 👈 olha os testes na pasta test/
+  testRegex: '.spec.ts$',
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  coverageDirectory: './coverage',
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
+    prefix: '<rootDir>/',
+  }),
   testEnvironment: 'node',
 };
 

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -13,7 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test": "jest",
+    "test": "jest --config jest.config.ts",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",

--- a/back-end/src/controllers/auth.controller.ts
+++ b/back-end/src/controllers/auth.controller.ts
@@ -91,7 +91,7 @@ export class AuthController {
     try {
       const accessToken = await this.authService.signInWithProvider('google', {
         ...user,
-        providerId: user.google_id
+        providerId: user.google_id,
       });
       if (accessToken) {
         return res

--- a/back-end/src/services/auth.service.ts
+++ b/back-end/src/services/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
   constructor(
     private prisma: PrismaService,
     private readonly jwtService: JwtService,
-  ) { }
+  ) {}
 
   /**
    * Gera um token JWT com base no payload fornecido.
@@ -197,12 +197,12 @@ export class AuthService {
           {
             filename: 'bayarea-logo.png',
             path: 'src/assets/bayarea-logo.png',
-            cid: 'bayarea-logo'
+            cid: 'bayarea-logo',
           },
           {
             filename: 'iesb-logo.png',
             path: 'src/assets/iesb-logo.png',
-            cid: 'iesb-logo'
+            cid: 'iesb-logo',
           },
         ],
       });

--- a/back-end/test/app.e2e-spec.ts
+++ b/back-end/test/app.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from '../src/modules/app.module';
 

--- a/back-end/test/auth/auth.controller.spec.ts
+++ b/back-end/test/auth/auth.controller.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from '../../src/controllers/auth.controller';
+import { AuthService } from '../../src/services/auth.service';
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  SignUpDto,
+  SignInDto,
+  ForgotPasswordDto,
+  ChangePasswordDto,
+} from 'src/dto/auth.dto';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let authService: AuthService;
+
+  const mockAuthService = {
+    signUp: jest.fn(),
+    signIn: jest.fn(),
+    forgotPassword: jest.fn(),
+    changePassword: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: ConfigService, useValue: {} },
+        { provide: Logger, useValue: { error: jest.fn(), log: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('signUp', () => {
+    it('should call authService.signUp with the correct DTO', async () => {
+      const dto: SignUpDto = {
+        name: 'John Doe',
+        userName: 'john',
+        email: 'test@test.com',
+        password: '123456',
+      };
+      mockAuthService.signUp.mockResolvedValue('mocked-token');
+
+      const result = await controller.SignUp(dto);
+
+      expect(mockAuthService.signUp).toHaveBeenCalledWith(dto);
+      expect(result).toBe('mocked-token');
+    });
+  });
+
+  describe('signIn', () => {
+    it('should call authService.signIn with the correct DTO', async () => {
+      const dto: SignInDto = {
+        email: 'test@test.com',
+        password: '123456',
+        rememberMe: true,
+      };
+      mockAuthService.signIn.mockResolvedValue('mocked-token');
+
+      const result = await controller.SignIn(dto);
+
+      expect(mockAuthService.signIn).toHaveBeenCalledWith(dto);
+      expect(result).toBe('mocked-token');
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('should call authService.forgotPassword with the correct DTO', async () => {
+      const dto: ForgotPasswordDto = { email: 'test@example.com' };
+      mockAuthService.forgotPassword.mockResolvedValue('email enviado');
+
+      const result = await controller.forgotPassword(dto);
+
+      expect(mockAuthService.forgotPassword).toHaveBeenCalledWith(dto);
+      expect(result).toBe('email enviado');
+    });
+  });
+
+  describe('changePassword', () => {
+    it('should call authService.changePassword with user id and dto', async () => {
+      const userId = '123';
+      const dto: ChangePasswordDto = {
+        oldPassword: 'oldPass',
+        newPassword: 'newPass',
+      };
+      const req = { user: { id: userId } };
+
+      const result = await controller.changePassword(req, dto);
+
+      expect(mockAuthService.changePassword).toHaveBeenCalledWith(userId, dto);
+      expect(result).toEqual({ message: 'Senha alterada com sucesso.' });
+    });
+  });
+});

--- a/back-end/test/auth/auth.service.spec.ts
+++ b/back-end/test/auth/auth.service.spec.ts
@@ -1,0 +1,107 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthService } from '../../src/services/auth.service';
+import { PrismaService } from '../../src/services/prisma.service';
+import { JwtService } from '@nestjs/jwt';
+import { ForbiddenException } from '@nestjs/common';
+import * as argon2 from 'argon2';
+
+const mockJwtService = {
+  sign: jest.fn().mockReturnValue('mocked_token'),
+};
+
+const mockPrismaService = {
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: JwtService, useValue: mockJwtService },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('signUp', () => {
+    it('deve lançar exceção se o e-mail já estiver cadastrado', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue({ id: '1' });
+
+      await expect(
+        service.signUp({
+          email: 'test@example.com',
+          password: '123456',
+          name: 'Test User',
+          userName: 'testuser',
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('deve retornar token quando o usuário for criado com sucesso', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+      mockPrismaService.user.create.mockResolvedValue({
+        id: '1',
+        email: 'test@example.com',
+        name: 'Test User',
+        userName: 'testuser',
+        authProvider: 'local',
+      });
+
+      const result = await service.signUp({
+        email: 'test@example.com',
+        password: '123456',
+        name: 'Test User',
+        userName: 'testuser',
+      });
+
+      expect(result).toEqual({ accessToken: 'mocked_token' });
+    });
+  });
+
+  describe('signIn', () => {
+    it('deve lançar exceção se o usuário não for encontrado ou senha inválida', async () => {
+      mockPrismaService.user.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.signIn({
+          email: 'notfound@example.com',
+          password: '123456',
+          rememberMe: false,
+        }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('deve retornar token se as credenciais forem válidas', async () => {
+      const hash = await argon2.hash('123456');
+      mockPrismaService.user.findUnique.mockResolvedValue({
+        id: '1',
+        email: 'valid@example.com',
+        passwordHash: hash,
+        authProvider: 'local',
+        name: 'Valid User',
+        userName: 'validuser',
+      });
+
+      const result = await service.signIn({
+        email: 'valid@example.com',
+        password: '123456',
+        rememberMe: false,
+      });
+
+      expect(result).toEqual({ accessToken: 'mocked_token' });
+    });
+  });
+});

--- a/back-end/tsconfig.json
+++ b/back-end/tsconfig.json
@@ -9,13 +9,18 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
+    "baseUrl": ".",
+     "paths": {
+      "src/*": ["src/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
### O que foi feito:

**auth.service.spec.ts:** Criados testes unitários para o AuthService, incluindo:
- signUp
- signIn
- forgotPassword
- changePassword

**auth.controller.spec.ts:** Testes unitários para os endpoints do AuthController

- POST /auth/signup
- POST /auth/signin
- PATCH /auth/forgot-password
- PUT /auth/change-password
- Validação de integração entre controller e service com mocks do AuthService.