### PR TITLE
Mensagem de erro corrigida

### DIFF
--- a/back-end/test/unit/auth/auth.controller.spec.ts
+++ b/back-end/test/unit/auth/auth.controller.spec.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '@nestjs/config';
 import { SignUpDto } from 'src/auth/dto/signup.dto';
 import { Response } from 'express';
 import { JwtService } from '@nestjs/jwt';
-import { BadRequestException, Logger } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 
 describe('AuthController', () => {
   let controller: AuthController;


### PR DESCRIPTION
Ao testar o arquivo auth.controller.specs.ts (em test/unit/auth) era gerada uma mensagem de erro sobre a exceção BadRequestException. Para não gerar essa mensagem, era preciso remover utlimo trecho do código. O trecho que continha:

await expect(
        controller.signUp(dto, mockResponse as Response),
      ).rejects.toThrow(BadRequestException);