### PR TITLE
feat(prisma): add Backlog, Sprint and SprintBacklogItem models

### DIFF
--- a/back-end/prisma/migrations/20260407235145_add_backlog_sprint/migration.sql
+++ b/back-end/prisma/migrations/20260407235145_add_backlog_sprint/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "public"."Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+
+-- CreateEnum
+CREATE TYPE "public"."BacklogStatus" AS ENUM ('OPEN', 'IN_PROGRESS', 'DONE');
+
+-- CreateEnum
+CREATE TYPE "public"."SprintStatus" AS ENUM ('PLANNED', 'ACTIVE', 'COMPLETED');
+
+-- CreateTable
+CREATE TABLE "public"."Backlog" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "priority" "public"."Priority" NOT NULL DEFAULT 'MEDIUM',
+    "status" "public"."BacklogStatus" NOT NULL DEFAULT 'OPEN',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Backlog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Sprint" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "status" "public"."SprintStatus" NOT NULL DEFAULT 'PLANNED',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Sprint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SprintBacklogItem" (
+    "id" TEXT NOT NULL,
+    "sprintId" TEXT NOT NULL,
+    "backlogId" TEXT NOT NULL,
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SprintBacklogItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SprintBacklogItem_sprintId_backlogId_key" ON "public"."SprintBacklogItem"("sprintId", "backlogId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Backlog" ADD CONSTRAINT "Backlog_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "public"."Board"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Sprint" ADD CONSTRAINT "Sprint_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "public"."Board"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SprintBacklogItem" ADD CONSTRAINT "SprintBacklogItem_sprintId_fkey" FOREIGN KEY ("sprintId") REFERENCES "public"."Sprint"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SprintBacklogItem" ADD CONSTRAINT "SprintBacklogItem_backlogId_fkey" FOREIGN KEY ("backlogId") REFERENCES "public"."Backlog"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -43,6 +43,47 @@ model Board {
   members     BoardMember[]
   labels      Label[]
   lists       List[]
+  backlogs    Backlog[]
+  sprints     Sprint[]
+}
+
+model Backlog {
+  id          String              @id @default(uuid())
+  boardId     String
+  title       String
+  description String?
+  priority    Priority            @default(MEDIUM)
+  status      BacklogStatus       @default(OPEN)
+  board       Board               @relation(fields: [boardId], references: [id])
+  sprints     SprintBacklogItem[]
+  createdAt   DateTime            @default(now())
+  updatedAt   DateTime            @updatedAt
+}
+
+model Sprint {
+  id        String              @id @default(uuid())
+  boardId   String
+  name      String
+  startDate DateTime
+  endDate   DateTime
+  status    SprintStatus        @default(PLANNED)
+  board     Board               @relation(fields: [boardId], references: [id])
+  items     SprintBacklogItem[]
+  createdAt DateTime            @default(now())
+  updatedAt DateTime            @updatedAt
+}
+
+model SprintBacklogItem {
+  id          String    @id @default(uuid())
+  sprintId    String
+  backlogId   String
+  sprint      Sprint    @relation(fields: [sprintId], references: [id])
+  backlog     Backlog   @relation(fields: [backlogId], references: [id])
+  completedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@unique([sprintId, backlogId])
 }
 
 model BoardMember {
@@ -128,4 +169,23 @@ enum Status {
   IN_PROGRESS
   DONE
   ARCHIVED
+}
+
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
+enum BacklogStatus {
+  OPEN
+  IN_PROGRESS
+  DONE
+}
+
+enum SprintStatus {
+  PLANNED
+  ACTIVE
+  COMPLETED
 }


### PR DESCRIPTION
## Summary
- Adiciona models `Backlog`, `Sprint` e `SprintBacklogItem` no schema Prisma
- `Backlog` e `Sprint` atrelados a `Board` via `boardId`
- Pivot `SprintBacklogItem` com `@@unique([sprintId, backlogId])` pra impedir duplicata do mesmo item no mesmo sprint
- Enums `Priority`, `BacklogStatus`, `SprintStatus`
- Timestamps (`createdAt`/`updatedAt`) em todos os novos models
- ON DELETE RESTRICT nas FKs (default seguro do Prisma)

## Migration
`20260407235145_add_backlog_sprint` — só adiciona tabelas/enums novos, não altera nada existente.

## Test plan
- [x] `npx prisma validate` passa
- [x] `npx prisma migrate dev` aplica sem erro
- [x] Backend cria modules/services NestJS consumindo os models
