### PR TITLE
fix(board): my-role response shape

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,8 +9,13 @@ on:
 
 permissions: read-all
 
+# Concurrency expandida: agrupa por workflow + ref OU head_ref (PR).
+# Evita race-condition entre os triggers push e pull_request quando
+# ambos disparam pra mesma branch — o SonarCloud invalida análises
+# duplicadas concorrentes (ANALYSIS_MODE_INELIGIBLE) e uma delas
+# falha mesmo com Quality Gate OK.
 concurrency:
-  group: security-${{ github.ref }}
+  group: security-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -5,6 +5,7 @@ import { AnalysisModule } from '@/analysis/analysis.module';
 import { AuthModule } from '@/auth/auth.module';
 import { BoardModule } from '@/board/board.module';
 import { BoardMemberModule } from '@/board-member/board-member.module';
+import { LabelModule } from '@/label/label.module';
 import { EventsModule } from '@/events/events.module';
 import { HealthModule } from '@/health/health.module';
 import { ListModule } from '@/list/list.module';
@@ -29,6 +30,7 @@ import { TaskLogModule } from '@/task-log/task-log.module';
     TaskModule,
     TaskLogModule,
     BoardMemberModule,
+    LabelModule,
     HealthModule,
     AnalysisModule,
   ],

--- a/back-end/src/label/dto/create-label.dto.ts
+++ b/back-end/src/label/dto/create-label.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+
+export class CreateLabelDto {
+  @ApiProperty({ example: 'Bug', description: 'Nome da label' })
+  @IsString()
+  @IsNotEmpty({ message: 'Nome não pode estar vazio' })
+  @MaxLength(32)
+  name!: string;
+
+  @ApiProperty({ example: '#ef4444', description: 'Cor hex (#RGB ou #RRGGBB)' })
+  @IsString()
+  @Matches(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, {
+    message: 'Cor deve estar em formato hex (#RGB ou #RRGGBB)',
+  })
+  color!: string;
+}

--- a/back-end/src/label/dto/update-label.dto.ts
+++ b/back-end/src/label/dto/update-label.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateLabelDto } from './create-label.dto';
+
+export class UpdateLabelDto extends PartialType(CreateLabelDto) {}

--- a/back-end/src/label/label.controller.ts
+++ b/back-end/src/label/label.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@/auth/guards/jwt.guard';
+import { CurrentUser } from '@/auth/strategy/decorators/current-user.decorator';
+import { AuthenticatedUser } from '@/types/user.interface';
+
+import { CreateLabelDto } from './dto/create-label.dto';
+import { UpdateLabelDto } from './dto/update-label.dto';
+import { LabelService } from './label.service';
+
+@ApiCookieAuth()
+@ApiTags('Labels')
+@UseGuards(JwtAuthGuard)
+@Controller({ version: '1' })
+export class LabelController {
+  constructor(private readonly labelService: LabelService) {}
+
+  @ApiOperation({ summary: 'Lista as labels do board' })
+  @ApiResponse({ status: 200, description: 'Lista retornada' })
+  @Get('boards/:boardId/labels')
+  list(
+    @Param('boardId') boardId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.labelService.listByBoard(boardId, user.id);
+  }
+
+  @ApiOperation({ summary: 'Cria uma label no board (admin)' })
+  @ApiResponse({ status: 201, description: 'Label criada' })
+  @ApiResponse({ status: 403, description: 'Sem permissão' })
+  @Post('boards/:boardId/labels')
+  create(
+    @Param('boardId') boardId: string,
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: CreateLabelDto,
+  ) {
+    return this.labelService.create(boardId, user.id, dto);
+  }
+
+  @ApiOperation({ summary: 'Atualiza uma label (admin)' })
+  @ApiResponse({ status: 200, description: 'Label atualizada' })
+  @ApiResponse({ status: 403, description: 'Sem permissão' })
+  @ApiResponse({ status: 404, description: 'Label não encontrada' })
+  @Patch('labels/:labelId')
+  update(
+    @Param('labelId') labelId: string,
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateLabelDto,
+  ) {
+    return this.labelService.update(labelId, user.id, dto);
+  }
+
+  @ApiOperation({ summary: 'Remove uma label (admin)' })
+  @ApiResponse({ status: 200, description: 'Label removida' })
+  @ApiResponse({ status: 403, description: 'Sem permissão' })
+  @ApiResponse({ status: 404, description: 'Label não encontrada' })
+  @Delete('labels/:labelId')
+  remove(
+    @Param('labelId') labelId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.labelService.remove(labelId, user.id);
+  }
+
+  @ApiOperation({ summary: 'Atribui uma label a uma tarefa' })
+  @ApiResponse({ status: 200, description: 'Label atribuída' })
+  @Post('tasks/:taskId/labels/:labelId')
+  addToTask(
+    @Param('taskId') taskId: string,
+    @Param('labelId') labelId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.labelService.addToTask(taskId, labelId, user.id);
+  }
+
+  @ApiOperation({ summary: 'Remove uma label de uma tarefa' })
+  @ApiResponse({ status: 200, description: 'Label removida da tarefa' })
+  @Delete('tasks/:taskId/labels/:labelId')
+  removeFromTask(
+    @Param('taskId') taskId: string,
+    @Param('labelId') labelId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.labelService.removeFromTask(taskId, labelId, user.id);
+  }
+}

--- a/back-end/src/label/label.module.ts
+++ b/back-end/src/label/label.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '@/prisma/prisma.module';
+
+import { LabelController } from './label.controller';
+import { LabelService } from './label.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [LabelController],
+  providers: [LabelService],
+})
+export class LabelModule {}

--- a/back-end/src/label/label.service.ts
+++ b/back-end/src/label/label.service.ts
@@ -1,0 +1,121 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { PrismaService } from '@/prisma/prisma.service';
+
+import { CreateLabelDto } from './dto/create-label.dto';
+import { UpdateLabelDto } from './dto/update-label.dto';
+
+@Injectable()
+export class LabelService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Garante que o usuário é admin/owner do board (necessário pra criar/editar/excluir labels). */
+  private async assertBoardAdmin(boardId: string, userId: string) {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: { members: { where: { userId } } },
+    });
+    if (!board) throw new NotFoundException('Board não encontrado');
+    const isOwner = board.ownerId === userId;
+    const isAdmin = board.members[0]?.role === 'ADMIN';
+    if (!isOwner && !isAdmin) {
+      throw new ForbiddenException(
+        'Apenas administradores podem gerenciar labels do board',
+      );
+    }
+  }
+
+  /** Garante que o usuário tem acesso ao board (qualquer membro). */
+  private async assertBoardAccess(boardId: string, userId: string) {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: { members: { where: { userId } } },
+    });
+    if (!board) throw new NotFoundException('Board não encontrado');
+    const isOwner = board.ownerId === userId;
+    const isMember = board.members.length > 0;
+    if (!isOwner && !isMember) {
+      throw new ForbiddenException('Você não tem acesso a este board');
+    }
+  }
+
+  async listByBoard(boardId: string, userId: string) {
+    await this.assertBoardAccess(boardId, userId);
+    return this.prisma.label.findMany({
+      where: { boardId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async create(boardId: string, userId: string, dto: CreateLabelDto) {
+    await this.assertBoardAdmin(boardId, userId);
+    return this.prisma.label.create({
+      data: { boardId, name: dto.name, color: dto.color },
+    });
+  }
+
+  async update(labelId: string, userId: string, dto: UpdateLabelDto) {
+    const label = await this.prisma.label.findUnique({
+      where: { id: labelId },
+    });
+    if (!label) throw new NotFoundException('Label não encontrada');
+    await this.assertBoardAdmin(label.boardId, userId);
+    return this.prisma.label.update({
+      where: { id: labelId },
+      data: { ...dto },
+    });
+  }
+
+  async remove(labelId: string, userId: string) {
+    const label = await this.prisma.label.findUnique({
+      where: { id: labelId },
+    });
+    if (!label) throw new NotFoundException('Label não encontrada');
+    await this.assertBoardAdmin(label.boardId, userId);
+    await this.prisma.taskLabel.deleteMany({ where: { labelId } });
+    return this.prisma.label.delete({ where: { id: labelId } });
+  }
+
+  /** Atribui uma label a uma task (idempotente). */
+  async addToTask(taskId: string, labelId: string, userId: string) {
+    const task = await this.prisma.task.findFirst({
+      where: { id: taskId, deletedAt: null },
+      include: { list: true },
+    });
+    if (!task) throw new NotFoundException('Tarefa não encontrada');
+    const label = await this.prisma.label.findUnique({
+      where: { id: labelId },
+    });
+    if (!label) throw new NotFoundException('Label não encontrada');
+    if (label.boardId !== task.list.boardId) {
+      throw new ForbiddenException(
+        'A label pertence a outro board',
+      );
+    }
+    await this.assertBoardAccess(label.boardId, userId);
+
+    await this.prisma.taskLabel.upsert({
+      where: { taskId_labelId: { taskId, labelId } },
+      update: {},
+      create: { taskId, labelId },
+    });
+    return { message: 'Label atribuída à tarefa' };
+  }
+
+  async removeFromTask(taskId: string, labelId: string, userId: string) {
+    const task = await this.prisma.task.findFirst({
+      where: { id: taskId, deletedAt: null },
+      include: { list: true },
+    });
+    if (!task) throw new NotFoundException('Tarefa não encontrada');
+    await this.assertBoardAccess(task.list.boardId, userId);
+    await this.prisma.taskLabel.deleteMany({
+      where: { taskId, labelId },
+    });
+    return { message: 'Label removida da tarefa' };
+  }
+}

--- a/back-end/src/prisma/queries.ts
+++ b/back-end/src/prisma/queries.ts
@@ -13,7 +13,12 @@ export class PrismaQueries {
   } satisfies Prisma.BoardInclude;
 
   listInclude = {
-    tasks: true,
+    tasks: {
+      where: { deletedAt: null },
+      include: {
+        labels: { include: { label: true } },
+      },
+    },
     board: true,
   } satisfies Prisma.ListInclude;
 

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -85,6 +85,7 @@ export default function BoardPage() {
   const [search, setSearch] = useState("");
   const [assigneeFilter, setAssigneeFilter] = useState<string>("__all__");
   const [showMineOnly, setShowMineOnly] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<string>("__all__");
 
   const { data: boardData, isLoading: loadingBoard } = useQuery({
     queryKey: ["board", boardId],
@@ -357,7 +358,10 @@ export default function BoardPage() {
               Minhas tarefas
             </Button>
           )}
-          {(search || assigneeFilter !== "__all__" || showMineOnly) && (
+          {(search ||
+            assigneeFilter !== "__all__" ||
+            showMineOnly ||
+            statusFilter !== "__all__") && (
             <Button
               type="button"
               variant="ghost"
@@ -366,6 +370,7 @@ export default function BoardPage() {
                 setSearch("");
                 setAssigneeFilter("__all__");
                 setShowMineOnly(false);
+                setStatusFilter("__all__");
               }}
               className="gap-1.5"
             >
@@ -373,6 +378,35 @@ export default function BoardPage() {
               Limpar
             </Button>
           )}
+        </div>
+      )}
+
+      {/* Pills de status */}
+      {lists.length > 0 && (
+        <div className="flex gap-2 flex-wrap items-center">
+          <span className="text-xs text-[#94A3B8]">Status:</span>
+          {[
+            { value: "__all__", label: "Todos", className: "bg-slate-100 text-slate-700" },
+            { value: "TODO", label: "A fazer", className: "bg-slate-100 text-slate-700" },
+            { value: "IN_PROGRESS", label: "Em progresso", className: "bg-amber-100 text-amber-700" },
+            { value: "DONE", label: "Concluído", className: "bg-emerald-100 text-emerald-700" },
+          ].map((opt) => {
+            const active = statusFilter === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setStatusFilter(opt.value)}
+                className={`text-xs px-2.5 py-1 rounded-full transition-all ${
+                  active
+                    ? "bg-red-600 text-white"
+                    : `${opt.className} hover:opacity-80`
+                }`}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
         </div>
       )}
 
@@ -424,12 +458,16 @@ export default function BoardPage() {
                 if (showMineOnly && myUserId && t.assigneeId !== myUserId) {
                   return false;
                 }
+                if (statusFilter !== "__all__" && t.status !== statusFilter) {
+                  return false;
+                }
                 return true;
               });
               const hasActiveFilter =
                 searchLower !== "" ||
                 assigneeFilter !== "__all__" ||
-                showMineOnly;
+                showMineOnly ||
+                statusFilter !== "__all__";
               return (
                 <div
                   key={list.id}

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2, Pencil } from "lucide-react";
+import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2, Pencil, Search, X } from "lucide-react";
 import { toast } from "sonner";
 import {
   DragDropContext,
@@ -13,6 +13,14 @@ import {
 } from "@hello-pangea/dnd";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -73,6 +81,8 @@ export default function BoardPage() {
   const [editBoardOpen, setEditBoardOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
+  const [search, setSearch] = useState("");
+  const [assigneeFilter, setAssigneeFilter] = useState<string>("__all__");
 
   const { data: boardData, isLoading: loadingBoard } = useQuery({
     queryKey: ["board", boardId],
@@ -291,6 +301,54 @@ export default function BoardPage() {
         </div>
       </div>
 
+      {/* Filtros */}
+      {lists.length > 0 && (
+        <div className="flex gap-2 items-center">
+          <div className="relative flex-1 max-w-md">
+            <Search
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-[#94A3B8] pointer-events-none"
+            />
+            <Input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Buscar por título ou descrição..."
+              className="pl-9"
+            />
+          </div>
+          <Select value={assigneeFilter} onValueChange={setAssigneeFilter}>
+            <SelectTrigger className="w-56">
+              <SelectValue placeholder="Filtrar por responsável" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all__">Todos os responsáveis</SelectItem>
+              <SelectItem value="__unassigned__">Sem responsável</SelectItem>
+              {members.map((m) => (
+                <SelectItem key={m.userId} value={m.userId}>
+                  {m.user.name || m.user.userName || m.user.email || m.userId}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {(search || assigneeFilter !== "__all__") && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSearch("");
+                setAssigneeFilter("__all__");
+              }}
+              className="gap-1.5"
+            >
+              <X size={14} />
+              Limpar
+            </Button>
+          )}
+        </div>
+      )}
+
       {/* Kanban */}
       {lists.length === 0 ? (
         <div className="rounded-xl bg-white shadow-sm border border-[#E2E8F0] p-12 text-center">
@@ -318,9 +376,28 @@ export default function BoardPage() {
         <DragDropContext onDragEnd={handleDragEnd}>
           <div className="flex gap-4 overflow-x-auto pb-2">
             {lists.map((list) => {
-              const tasks = (list.tasks ?? [])
+              const allTasks = (list.tasks ?? [])
                 .slice()
                 .sort((a, b) => a.position - b.position);
+              const searchLower = search.trim().toLowerCase();
+              const tasks = allTasks.filter((t) => {
+                if (searchLower) {
+                  const matchText =
+                    t.title.toLowerCase().includes(searchLower) ||
+                    (t.description?.toLowerCase().includes(searchLower) ?? false);
+                  if (!matchText) return false;
+                }
+                if (assigneeFilter !== "__all__") {
+                  if (assigneeFilter === "__unassigned__") {
+                    if (t.assigneeId) return false;
+                  } else if (t.assigneeId !== assigneeFilter) {
+                    return false;
+                  }
+                }
+                return true;
+              });
+              const hasActiveFilter =
+                searchLower !== "" || assigneeFilter !== "__all__";
               return (
                 <div
                   key={list.id}
@@ -332,7 +409,7 @@ export default function BoardPage() {
                     </h3>
                     <div className="flex items-center gap-1">
                       <span className="text-xs text-[#94A3B8] bg-white border border-[#E2E8F0] rounded px-1.5 py-0.5">
-                        {tasks.length}
+                        {hasActiveFilter ? `${tasks.length}/${allTasks.length}` : tasks.length}
                       </span>
                       {isAdmin && (
                         <DropdownMenu>
@@ -387,7 +464,7 @@ export default function BoardPage() {
                             key={t.id}
                             draggableId={t.id}
                             index={idx}
-                            isDragDisabled={!canEditTasks}
+                            isDragDisabled={!canEditTasks || hasActiveFilter}
                           >
                             {(dragProvided, dragSnapshot) => (
                               <div

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2, Pencil, Search, X } from "lucide-react";
+import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2, Pencil, Search, X, Tag } from "lucide-react";
 import { toast } from "sonner";
 import {
   DragDropContext,
@@ -38,6 +38,7 @@ import { CreateTaskDialog } from "@/features/board/create-task-dialog";
 import { EditTaskDialog } from "@/features/board/edit-task-dialog";
 import { EditListDialog } from "@/features/board/edit-list-dialog";
 import { EditBoardDialog } from "@/features/board/edit-board-dialog";
+import { LabelsDialog } from "@/features/board/labels-dialog";
 import { MembersDialog } from "@/features/board/members-dialog";
 import { TaskCard } from "@/features/board/task-card";
 
@@ -81,6 +82,7 @@ export default function BoardPage() {
   const [editingList, setEditingList] = useState<{ id: string; title: string } | null>(null);
   const [editBoardOpen, setEditBoardOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
+  const [labelsOpen, setLabelsOpen] = useState(false);
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
   const [search, setSearch] = useState("");
   const [assigneeFilter, setAssigneeFilter] = useState<string>("__all__");
@@ -279,6 +281,16 @@ export default function BoardPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setLabelsOpen(true)}
+            className="gap-1.5"
+            title="Gerenciar labels"
+          >
+            <Tag size={16} />
+            Labels
+          </Button>
           <Button
             type="button"
             variant="outline"
@@ -632,6 +644,13 @@ export default function BoardPage() {
         currentDescription={board.description ?? ""}
         isOpen={editBoardOpen}
         onClose={() => setEditBoardOpen(false)}
+      />
+
+      <LabelsDialog
+        boardId={boardId}
+        isOpen={labelsOpen}
+        onClose={() => setLabelsOpen(false)}
+        canManage={isAdmin}
       />
     </div>
   );

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -336,12 +336,16 @@ export default function BoardPage() {
                     </div>
                   </div>
 
-                  <Droppable droppableId={list.id} type="task">
+                  <Droppable
+                    droppableId={list.id}
+                    type="task"
+                    ignoreContainerClipping
+                  >
                     {(provided, snapshot) => (
                       <div
                         ref={provided.innerRef}
                         {...provided.droppableProps}
-                        className={`flex-1 overflow-y-auto space-y-2 pr-1 transition-colors rounded-md ${
+                        className={`flex-1 overflow-y-auto space-y-2 pr-1 transition-colors rounded-md min-h-[80px] ${
                           snapshot.isDraggingOver ? "bg-red-50/40" : ""
                         }`}
                       >

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState, useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  type DropResult,
+} from "@hello-pangea/dnd";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -15,6 +21,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { getBoardById } from "@/lib/actions/board";
 import { getAllList, deleteList } from "@/lib/actions/list";
+import { moveTask, moveTaskOtherList } from "@/lib/actions/task";
 import { getMyRoleOnBoard, getBoardMembers } from "@/lib/actions/members";
 
 import { CreateListDialog } from "@/features/board/create-list-dialog";
@@ -54,12 +61,14 @@ interface ListWithTasks {
 export default function BoardPage() {
   const params = useParams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const boardId = params.id as string;
 
   const [createListOpen, setCreateListOpen] = useState(false);
   const [createTaskListId, setCreateTaskListId] = useState<string | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [membersOpen, setMembersOpen] = useState(false);
+  const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
 
   const { data: boardData, isLoading: loadingBoard } = useQuery({
     queryKey: ["board", boardId],
@@ -86,10 +95,17 @@ export default function BoardPage() {
   });
 
   const board = boardData?.success ? boardData.data : null;
-  const lists: ListWithTasks[] = useMemo(() => {
+  const serverLists: ListWithTasks[] = useMemo(() => {
     if (!listsData?.success) return [];
     return (listsData.data as ListWithTasks[]) ?? [];
   }, [listsData]);
+
+  // Reset optimistic state when server data refreshes
+  useEffect(() => {
+    setOptimisticLists(null);
+  }, [listsData]);
+
+  const lists = optimisticLists ?? serverLists;
 
   const myRole = roleData?.success ? roleData.data.role : null;
   const isAdmin = myRole === "OWNER" || myRole === "ADMIN";
@@ -136,6 +152,67 @@ export default function BoardPage() {
     } else {
       toast.error(r.error || "Erro ao excluir lista");
     }
+  }
+
+  async function handleDragEnd(result: DropResult) {
+    const { source, destination, draggableId } = result;
+    if (!destination) return;
+    if (
+      source.droppableId === destination.droppableId &&
+      source.index === destination.index
+    ) {
+      return;
+    }
+    if (!canEditTasks) {
+      toast.error("Você não tem permissão para mover tarefas");
+      return;
+    }
+
+    // Build optimistic state
+    const sourceListId = source.droppableId;
+    const destListId = destination.droppableId;
+    const next = lists.map((l) => ({
+      ...l,
+      tasks: [...(l.tasks ?? [])].sort((a, b) => a.position - b.position),
+    }));
+    const srcList = next.find((l) => l.id === sourceListId);
+    const dstList = next.find((l) => l.id === destListId);
+    if (!srcList || !dstList || !srcList.tasks) return;
+
+    const [moved] = srcList.tasks.splice(source.index, 1);
+    if (!moved) return;
+    if (!dstList.tasks) dstList.tasks = [];
+
+    if (sourceListId === destListId) {
+      dstList.tasks.splice(destination.index, 0, moved);
+    } else {
+      moved.listId = destListId;
+      dstList.tasks.splice(destination.index, 0, moved);
+    }
+
+    // Reassign positions
+    srcList.tasks.forEach((t, i) => {
+      t.position = i;
+    });
+    if (sourceListId !== destListId) {
+      dstList.tasks.forEach((t, i) => {
+        t.position = i;
+      });
+    }
+
+    setOptimisticLists(next);
+
+    // Persist
+    const r =
+      sourceListId === destListId
+        ? await moveTask(draggableId, destination.index)
+        : await moveTaskOtherList(draggableId, destination.index, destListId);
+
+    if (!r.success) {
+      toast.error(r.error || "Erro ao mover tarefa");
+      setOptimisticLists(null);
+    }
+    queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
   }
 
   const initial = (board.name ?? "?")[0].toUpperCase();
@@ -213,74 +290,108 @@ export default function BoardPage() {
           )}
         </div>
       ) : (
-        <div className="flex gap-4 overflow-x-auto pb-2">
-          {lists.map((list) => {
-            const tasks = (list.tasks ?? []).slice().sort((a, b) => a.position - b.position);
-            return (
-              <div
-                key={list.id}
-                className="flex-shrink-0 w-80 bg-[#F8FAFC] rounded-xl border border-[#E2E8F0] p-3 flex flex-col max-h-[calc(100vh-280px)]"
-              >
-                <div className="flex items-center justify-between mb-3 px-1">
-                  <h3 className="font-semibold text-[#1E293B] text-sm truncate">
-                    {list.title}
-                  </h3>
-                  <div className="flex items-center gap-1">
-                    <span className="text-xs text-[#94A3B8] bg-white border border-[#E2E8F0] rounded px-1.5 py-0.5">
-                      {tasks.length}
-                    </span>
-                    {isAdmin && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="icon"
-                            className="h-7 w-7"
-                            aria-label="Opções da lista"
-                          >
-                            <MoreHorizontal size={14} />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() => handleDeleteList(list.id, list.title)}
-                            className="text-red-600"
-                          >
-                            <Trash2 size={14} className="mr-2" />
-                            Excluir lista
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                    )}
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {lists.map((list) => {
+              const tasks = (list.tasks ?? [])
+                .slice()
+                .sort((a, b) => a.position - b.position);
+              return (
+                <div
+                  key={list.id}
+                  className="flex-shrink-0 w-80 bg-[#F8FAFC] rounded-xl border border-[#E2E8F0] p-3 flex flex-col max-h-[calc(100vh-280px)]"
+                >
+                  <div className="flex items-center justify-between mb-3 px-1">
+                    <h3 className="font-semibold text-[#1E293B] text-sm truncate">
+                      {list.title}
+                    </h3>
+                    <div className="flex items-center gap-1">
+                      <span className="text-xs text-[#94A3B8] bg-white border border-[#E2E8F0] rounded px-1.5 py-0.5">
+                        {tasks.length}
+                      </span>
+                      {isAdmin && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              className="h-7 w-7"
+                              aria-label="Opções da lista"
+                            >
+                              <MoreHorizontal size={14} />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => handleDeleteList(list.id, list.title)}
+                              className="text-red-600"
+                            >
+                              <Trash2 size={14} className="mr-2" />
+                              Excluir lista
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
+                    </div>
                   </div>
-                </div>
 
-                <div className="flex-1 overflow-y-auto space-y-2 pr-1">
-                  {tasks.map((t) => (
-                    <TaskCard
-                      key={t.id}
-                      task={t}
-                      members={members}
-                      onClick={() => setEditingTask(t)}
-                    />
-                  ))}
-                </div>
+                  <Droppable droppableId={list.id} type="task">
+                    {(provided, snapshot) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.droppableProps}
+                        className={`flex-1 overflow-y-auto space-y-2 pr-1 transition-colors rounded-md ${
+                          snapshot.isDraggingOver ? "bg-red-50/40" : ""
+                        }`}
+                      >
+                        {tasks.map((t, idx) => (
+                          <Draggable
+                            key={t.id}
+                            draggableId={t.id}
+                            index={idx}
+                            isDragDisabled={!canEditTasks}
+                          >
+                            {(dragProvided, dragSnapshot) => (
+                              <div
+                                ref={dragProvided.innerRef}
+                                {...dragProvided.draggableProps}
+                                {...dragProvided.dragHandleProps}
+                                className={
+                                  dragSnapshot.isDragging
+                                    ? "rotate-1 shadow-lg"
+                                    : ""
+                                }
+                              >
+                                <TaskCard
+                                  task={t}
+                                  members={members}
+                                  onClick={() => setEditingTask(t)}
+                                />
+                              </div>
+                            )}
+                          </Draggable>
+                        ))}
+                        {provided.placeholder}
+                      </div>
+                    )}
+                  </Droppable>
 
-                {canEditTasks && (
-                  <button
-                    type="button"
-                    onClick={() => setCreateTaskListId(list.id)}
-                    className="mt-2 w-full flex items-center justify-center gap-1.5 text-sm text-[#64748B] hover:text-[#C01010] hover:bg-white rounded-lg py-2 transition-colors"
-                  >
-                    <Plus size={14} />
-                    Adicionar tarefa
-                  </button>
-                )}
-              </div>
-            );
-          })}
-        </div>
+                  {canEditTasks && (
+                    <button
+                      type="button"
+                      onClick={() => setCreateTaskListId(list.id)}
+                      className="mt-2 w-full flex items-center justify-center gap-1.5 text-sm text-[#64748B] hover:text-[#C01010] hover:bg-white rounded-lg py-2 transition-colors"
+                    >
+                      <Plus size={14} />
+                      Adicionar tarefa
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </DragDropContext>
       )}
 
       {/* Dialogs */}

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useParams, useRouter } from "next/navigation";
-import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2 } from "lucide-react";
+import { ArrowLeft, Plus, Users, Layout, MoreHorizontal, Trash2, Pencil } from "lucide-react";
 import { toast } from "sonner";
 import {
   DragDropContext,
@@ -27,6 +27,7 @@ import { getMyRoleOnBoard, getBoardMembers } from "@/lib/actions/members";
 import { CreateListDialog } from "@/features/board/create-list-dialog";
 import { CreateTaskDialog } from "@/features/board/create-task-dialog";
 import { EditTaskDialog } from "@/features/board/edit-task-dialog";
+import { EditListDialog } from "@/features/board/edit-list-dialog";
 import { MembersDialog } from "@/features/board/members-dialog";
 import { TaskCard } from "@/features/board/task-card";
 
@@ -67,6 +68,7 @@ export default function BoardPage() {
   const [createListOpen, setCreateListOpen] = useState(false);
   const [createTaskListId, setCreateTaskListId] = useState<string | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [editingList, setEditingList] = useState<{ id: string; title: string } | null>(null);
   const [membersOpen, setMembersOpen] = useState(false);
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
 
@@ -324,6 +326,14 @@ export default function BoardPage() {
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
+                              onClick={() =>
+                                setEditingList({ id: list.id, title: list.title })
+                              }
+                            >
+                              <Pencil size={14} className="mr-2" />
+                              Renomear
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
                               onClick={() => handleDeleteList(list.id, list.title)}
                               className="text-red-600"
                             >
@@ -435,6 +445,14 @@ export default function BoardPage() {
         isOpen={membersOpen}
         onClose={() => setMembersOpen(false)}
         canManage={isAdmin}
+      />
+
+      <EditListDialog
+        boardId={boardId}
+        listId={editingList?.id ?? null}
+        currentTitle={editingList?.title ?? ""}
+        isOpen={!!editingList}
+        onClose={() => setEditingList(null)}
       />
     </div>
   );

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -31,6 +31,7 @@ import { getBoardById } from "@/lib/actions/board";
 import { getAllList, deleteList } from "@/lib/actions/list";
 import { moveTask, moveTaskOtherList } from "@/lib/actions/task";
 import { getMyRoleOnBoard, getBoardMembers } from "@/lib/actions/members";
+import { getUserProfile } from "@/lib/actions/profile";
 
 import { CreateListDialog } from "@/features/board/create-list-dialog";
 import { CreateTaskDialog } from "@/features/board/create-task-dialog";
@@ -83,6 +84,7 @@ export default function BoardPage() {
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
   const [search, setSearch] = useState("");
   const [assigneeFilter, setAssigneeFilter] = useState<string>("__all__");
+  const [showMineOnly, setShowMineOnly] = useState(false);
 
   const { data: boardData, isLoading: loadingBoard } = useQuery({
     queryKey: ["board", boardId],
@@ -107,6 +109,15 @@ export default function BoardPage() {
     queryFn: () => getBoardMembers(boardId),
     enabled: !!boardId,
   });
+
+  const { data: profileData } = useQuery({
+    queryKey: ["me-profile"],
+    queryFn: getUserProfile,
+    staleTime: 5 * 60 * 1000,
+  });
+  const myUserId = (profileData?.success
+    ? (profileData.data as { id?: string })?.id
+    : undefined) as string | undefined;
 
   const board = boardData?.success ? boardData.data : null;
   const serverLists: ListWithTasks[] = useMemo(() => {
@@ -331,7 +342,22 @@ export default function BoardPage() {
               ))}
             </SelectContent>
           </Select>
-          {(search || assigneeFilter !== "__all__") && (
+          {myUserId && (
+            <Button
+              type="button"
+              variant={showMineOnly ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowMineOnly((v) => !v)}
+              className={
+                showMineOnly
+                  ? "gap-1.5 bg-red-600 hover:bg-red-700 text-white"
+                  : "gap-1.5"
+              }
+            >
+              Minhas tarefas
+            </Button>
+          )}
+          {(search || assigneeFilter !== "__all__" || showMineOnly) && (
             <Button
               type="button"
               variant="ghost"
@@ -339,6 +365,7 @@ export default function BoardPage() {
               onClick={() => {
                 setSearch("");
                 setAssigneeFilter("__all__");
+                setShowMineOnly(false);
               }}
               className="gap-1.5"
             >
@@ -394,10 +421,15 @@ export default function BoardPage() {
                     return false;
                   }
                 }
+                if (showMineOnly && myUserId && t.assigneeId !== myUserId) {
+                  return false;
+                }
                 return true;
               });
               const hasActiveFilter =
-                searchLower !== "" || assigneeFilter !== "__all__";
+                searchLower !== "" ||
+                assigneeFilter !== "__all__" ||
+                showMineOnly;
               return (
                 <div
                   key={list.id}
@@ -538,6 +570,7 @@ export default function BoardPage() {
         members={members}
         canAssign={isAdmin}
         canDelete={canEditTasks}
+        canViewHistory={isAdmin}
       />
 
       <MembersDialog

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -28,6 +28,7 @@ import { CreateListDialog } from "@/features/board/create-list-dialog";
 import { CreateTaskDialog } from "@/features/board/create-task-dialog";
 import { EditTaskDialog } from "@/features/board/edit-task-dialog";
 import { EditListDialog } from "@/features/board/edit-list-dialog";
+import { EditBoardDialog } from "@/features/board/edit-board-dialog";
 import { MembersDialog } from "@/features/board/members-dialog";
 import { TaskCard } from "@/features/board/task-card";
 
@@ -69,6 +70,7 @@ export default function BoardPage() {
   const [createTaskListId, setCreateTaskListId] = useState<string | null>(null);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [editingList, setEditingList] = useState<{ id: string; title: string } | null>(null);
+  const [editBoardOpen, setEditBoardOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
 
@@ -256,14 +258,26 @@ export default function BoardPage() {
             Membros ({members.length})
           </Button>
           {isAdmin && (
-            <Button
-              type="button"
-              onClick={() => setCreateListOpen(true)}
-              className="gap-1.5 bg-red-600 hover:bg-red-700 text-white"
-            >
-              <Plus size={16} />
-              Nova lista
-            </Button>
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setEditBoardOpen(true)}
+                className="gap-1.5"
+                title="Editar quadro"
+              >
+                <Pencil size={16} />
+                Editar
+              </Button>
+              <Button
+                type="button"
+                onClick={() => setCreateListOpen(true)}
+                className="gap-1.5 bg-red-600 hover:bg-red-700 text-white"
+              >
+                <Plus size={16} />
+                Nova lista
+              </Button>
+            </>
           )}
         </div>
       </div>
@@ -453,6 +467,14 @@ export default function BoardPage() {
         currentTitle={editingList?.title ?? ""}
         isOpen={!!editingList}
         onClose={() => setEditingList(null)}
+      />
+
+      <EditBoardDialog
+        boardId={boardId}
+        currentTitle={board.name ?? ""}
+        currentDescription={board.description ?? ""}
+        isOpen={editBoardOpen}
+        onClose={() => setEditBoardOpen(false)}
       />
     </div>
   );

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -401,7 +401,7 @@ export default function BoardPage() {
               return (
                 <div
                   key={list.id}
-                  className="flex-shrink-0 w-80 bg-[#F8FAFC] rounded-xl border border-[#E2E8F0] p-3 flex flex-col max-h-[calc(100vh-280px)]"
+                  className="flex-shrink-0 w-80 bg-[#F8FAFC] rounded-xl border border-[#E2E8F0] p-3 flex flex-col"
                 >
                   <div className="flex items-center justify-between mb-3 px-1">
                     <h3 className="font-semibold text-[#1E293B] text-sm truncate">
@@ -455,7 +455,7 @@ export default function BoardPage() {
                       <div
                         ref={provided.innerRef}
                         {...provided.droppableProps}
-                        className={`flex-1 overflow-y-auto space-y-2 pr-1 transition-colors rounded-md min-h-[80px] ${
+                        className={`space-y-2 pr-1 transition-colors rounded-md min-h-[80px] ${
                           snapshot.isDraggingOver ? "bg-red-50/40" : ""
                         }`}
                       >

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -246,6 +246,15 @@ export default function BoardPage() {
           ) : (
             <p className="text-sm text-[#94A3B8] mt-1 italic">Sem descrição</p>
           )}
+          {lists.length > 0 && (
+            <p className="text-xs text-[#94A3B8] mt-1.5">
+              {lists.length} {lists.length === 1 ? "lista" : "listas"} ·{" "}
+              {lists.reduce((sum, l) => sum + (l.tasks?.length ?? 0), 0)} tarefa
+              {lists.reduce((sum, l) => sum + (l.tasks?.length ?? 0), 0) === 1
+                ? ""
+                : "s"}
+            </p>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Button

--- a/front-end/app/dashboard/page.tsx
+++ b/front-end/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { Plus } from "lucide-react";
 import { getBoards } from "@/lib/actions/board";
 import { CreateBoardDialog } from "@/features/board/create-board-dialog";
+import { PendingTasks } from "@/features/dashboard/pending-tasks";
 
 const BOARD_COLORS = [
   "bg-red-500",
@@ -39,6 +40,7 @@ export default function Dashboard() {
 
   return (
     <div className="p-8 max-w-5xl mx-auto">
+      <PendingTasks />
       <div className="rounded-xl bg-white shadow-sm border border-[#E2E8F0] overflow-hidden">
         <div className="flex items-center justify-between px-6 py-4 border-b border-[#E2E8F0]">
           <div>

--- a/front-end/app/edit-profile/page.tsx
+++ b/front-end/app/edit-profile/page.tsx
@@ -23,7 +23,9 @@ export default function EditProfilePage() {
     }
 
     fetchUserProfile();
-  }, [profile]);
+    // Roda só no mount. NÃO incluir `profile` (gera loop infinito:
+    // setProfile -> re-render -> effect dispara -> setProfile -> ...).
+  }, []);
 
   return (
     <div className="p-8 max-w-225 my-12.5 mx-auto bg-white rounded-[10px] shadow-[0_3px_8px_rgba(0,0,0,0.233)] font-sans">

--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -3,16 +3,37 @@
 import { User, LogOut } from "lucide-react";
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
+import { useQuery } from "@tanstack/react-query";
 import { removeCookie } from "@/lib/utils/session-cookie";
+import { getUserProfile } from "@/lib/actions/profile";
 import styles from "./style.module.css";
 import { useSprintStore } from "@/stores/use-sprint-store";
 import { cn } from "@/lib/utils";
 import { NotificationsBell } from "./notifications-bell";
 
+interface UserProfile {
+  name?: string | null;
+  userName?: string | null;
+  email?: string | null;
+}
+
 export default function Header() {
   const router = useRouter();
   const pathname = usePathname();
   const { view, setView } = useSprintStore();
+
+  const { data: profileData } = useQuery({
+    queryKey: ["me-profile"],
+    queryFn: getUserProfile,
+    staleTime: 5 * 60 * 1000,
+  });
+  const profile = (profileData?.success ? profileData.data : null) as UserProfile | null;
+  const initial = (
+    profile?.name ||
+    profile?.userName ||
+    profile?.email ||
+    "?"
+  )[0]?.toUpperCase();
 
   const isSprintsPage = pathname === "/dashboard/sprints";
 
@@ -43,8 +64,13 @@ export default function Header() {
         <div className={styles.wrapper_header_helps}>
           <NotificationsBell />
           <div className={styles.profileContainer}>
-            <Link href="/edit-profile/" className={styles.profileImage} aria-label="Editar perfil">
-              <div className={styles.profileImageInner}></div>
+            <Link
+              href="/edit-profile/"
+              className="w-10 h-10 rounded-full bg-[#FEF2F2] text-[#C01010] flex items-center justify-center font-semibold text-base hover:bg-[#FEE2E2] transition-colors"
+              aria-label={`Editar perfil de ${profile?.name || profile?.userName || "usuário"}`}
+              title={profile?.name || profile?.userName || profile?.email || ""}
+            >
+              {initial}
             </Link>
             <div className={styles.dropdownMenu}>
               <Link href="/edit-profile/" className={styles.dropdownItem}>

--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -10,6 +10,7 @@ import styles from "./style.module.css";
 import { useSprintStore } from "@/stores/use-sprint-store";
 import { cn } from "@/lib/utils";
 import { NotificationsBell } from "./notifications-bell";
+import { ThemeToggle } from "./theme-toggle";
 
 interface UserProfile {
   name?: string | null;
@@ -62,6 +63,7 @@ export default function Header() {
         )}
 
         <div className={styles.wrapper_header_helps}>
+          <ThemeToggle />
           <NotificationsBell />
           <div className={styles.profileContainer}>
             <Link

--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Bell, User, LogOut } from "lucide-react";
+import { User, LogOut } from "lucide-react";
 import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { removeCookie } from "@/lib/utils/session-cookie";
 import styles from "./style.module.css";
 import { useSprintStore } from "@/stores/use-sprint-store";
 import { cn } from "@/lib/utils";
+import { NotificationsBell } from "./notifications-bell";
 
 export default function Header() {
   const router = useRouter();
@@ -40,7 +41,7 @@ export default function Header() {
         )}
 
         <div className={styles.wrapper_header_helps}>
-          <Bell size={32} color="#949494" strokeWidth={2} aria-label="Notificações" />
+          <NotificationsBell />
           <div className={styles.profileContainer}>
             <Link href="/edit-profile/" className={styles.profileImage} aria-label="Editar perfil">
               <div className={styles.profileImageInner}></div>

--- a/front-end/components/layout/header/notifications-bell.tsx
+++ b/front-end/components/layout/header/notifications-bell.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Bell, Check, X } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import {
+  getNotifications,
+  respondInvite,
+  type InviteNotification,
+} from "@/lib/actions/notifications";
+
+const roleLabel: Record<InviteNotification["role"], string> = {
+  ADMIN: "Administrador",
+  MEMBER: "Membro",
+  OBSERVER: "Observador",
+};
+
+function formatDate(d: string) {
+  try {
+    const date = new Date(d);
+    return date.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return d;
+  }
+}
+
+export function NotificationsBell() {
+  const queryClient = useQueryClient();
+  const [respondingId, setRespondingId] = useState<string | null>(null);
+
+  const { data } = useQuery({
+    queryKey: ["notifications"],
+    queryFn: getNotifications,
+    refetchInterval: 30_000,
+  });
+
+  const all: InviteNotification[] = data?.success ? data.data : [];
+  const pending = all.filter((n) => n.statusInvite === "PENDING");
+  const count = pending.length;
+
+  async function handleRespond(invite: InviteNotification, accept: boolean) {
+    setRespondingId(invite.id);
+    const r = await respondInvite(invite.board.id, invite.id, accept);
+    setRespondingId(null);
+    if (r.success) {
+      toast.success(accept ? "Convite aceito" : "Convite recusado");
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+      if (accept) {
+        queryClient.invalidateQueries({ queryKey: ["boards"] });
+      }
+    } else {
+      toast.error(r.error || "Erro ao responder convite");
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="relative inline-flex items-center justify-center hover:opacity-80 transition-opacity"
+          aria-label={`Notificações${count > 0 ? ` (${count} pendentes)` : ""}`}
+        >
+          <Bell size={28} color="#949494" strokeWidth={2} />
+          {count > 0 && (
+            <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white text-[10px] font-semibold flex items-center justify-center">
+              {count > 9 ? "9+" : count}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-80 p-0">
+        <div className="px-4 py-3 border-b border-[#E2E8F0]">
+          <p className="font-semibold text-sm text-[#1E293B]">Notificações</p>
+          <p className="text-xs text-[#94A3B8]">
+            {count === 0
+              ? "Sem convites pendentes"
+              : `${count} convite${count === 1 ? "" : "s"} aguardando resposta`}
+          </p>
+        </div>
+        <div className="max-h-[400px] overflow-y-auto">
+          {pending.length === 0 ? (
+            <div className="p-8 text-center text-sm text-[#94A3B8]">
+              Você está em dia! ✨
+            </div>
+          ) : (
+            pending.map((n) => (
+              <div
+                key={n.id}
+                className="p-4 border-b border-[#F1F5F9] last:border-0"
+              >
+                <p className="text-sm text-[#1E293B]">
+                  <strong>{n.sender.name || n.sender.userName}</strong> te
+                  convidou para o quadro{" "}
+                  <strong>{n.board.title}</strong>
+                </p>
+                <p className="text-xs text-[#94A3B8] mt-1">
+                  como <em>{roleLabel[n.role]}</em> · {formatDate(n.createdAt)}
+                </p>
+                <div className="flex gap-2 mt-3">
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() => handleRespond(n, true)}
+                    disabled={respondingId === n.id}
+                    className="bg-red-600 hover:bg-red-700 text-white h-8 px-3 gap-1"
+                  >
+                    <Check size={14} />
+                    Aceitar
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleRespond(n, false)}
+                    disabled={respondingId === n.id}
+                    className="h-8 px-3 gap-1"
+                  >
+                    <X size={14} />
+                    Recusar
+                  </Button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front-end/components/layout/header/theme-toggle.tsx
+++ b/front-end/components/layout/header/theme-toggle.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun, Monitor } from "lucide-react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  // Evita mismatch entre SSR e client
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        className="inline-flex items-center justify-center w-7 h-7"
+        aria-label="Alternar tema"
+      >
+        <Sun size={20} color="#949494" strokeWidth={2} />
+      </button>
+    );
+  }
+
+  const Icon = theme === "dark" ? Moon : theme === "system" ? Monitor : Sun;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center hover:opacity-80 transition-opacity"
+          aria-label="Alternar tema"
+        >
+          <Icon size={20} color="#949494" strokeWidth={2} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun size={14} className="mr-2" />
+          Claro
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon size={14} className="mr-2" />
+          Escuro
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor size={14} className="mr-2" />
+          Sistema
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front-end/features/board/create-task-dialog.tsx
+++ b/front-end/features/board/create-task-dialog.tsx
@@ -64,7 +64,8 @@ export function CreateTaskDialog({
       description: description.trim() || undefined,
       position: nextPosition,
       status: "TODO",
-      dueDate: dueDate || undefined,
+      // Input datetime-local retorna 'YYYY-MM-DDTHH:MM'; Prisma exige ISO-8601 completo
+      dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
       assigneeId: assigneeId !== UNASSIGNED ? assigneeId : null,
     });
     setLoading(false);

--- a/front-end/features/board/edit-board-dialog.tsx
+++ b/front-end/features/board/edit-board-dialog.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { updateBoard, deleteBoard } from "@/lib/actions/board";
+
+interface EditBoardDialogProps {
+  boardId: string;
+  currentTitle: string;
+  currentDescription?: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function EditBoardDialog({
+  boardId,
+  currentTitle,
+  currentDescription,
+  isOpen,
+  onClose,
+}: EditBoardDialogProps) {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+  const [title, setTitle] = useState(currentTitle);
+  const [description, setDescription] = useState(currentDescription ?? "");
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    setTitle(currentTitle);
+    setDescription(currentDescription ?? "");
+  }, [currentTitle, currentDescription, boardId]);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setSaving(true);
+    const r = await updateBoard(boardId, {
+      title: title.trim(),
+      description: description.trim() || undefined,
+    });
+    setSaving(false);
+    if (r.success) {
+      toast.success("Quadro atualizado");
+      queryClient.invalidateQueries({ queryKey: ["board", boardId] });
+      queryClient.invalidateQueries({ queryKey: ["boards"] });
+      onClose();
+    } else {
+      toast.error(r.error || "Erro ao atualizar quadro");
+    }
+  }
+
+  async function handleDelete() {
+    if (
+      !confirm(
+        `Excluir o quadro "${currentTitle}" e tudo associado a ele (listas, tarefas, convites)? Esta ação não pode ser desfeita.`,
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    const r = await deleteBoard(boardId);
+    setDeleting(false);
+    if (r.success) {
+      toast.success("Quadro excluído");
+      queryClient.invalidateQueries({ queryKey: ["boards"] });
+      onClose();
+      router.push("/dashboard");
+    } else {
+      toast.error(r.error || "Erro ao excluir quadro");
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Editar quadro</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSave} className="space-y-4 mt-2">
+          <div className="space-y-2">
+            <Label htmlFor="edit-board-title">Título</Label>
+            <Input
+              id="edit-board-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              autoFocus
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="edit-board-desc">Descrição</Label>
+            <Textarea
+              id="edit-board-desc"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={3}
+            />
+          </div>
+          <div className="flex justify-between gap-2 pt-2">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="text-red-600 hover:text-red-700 hover:bg-red-50"
+            >
+              <Trash2 size={16} className="mr-1" />
+              {deleting ? "Excluindo..." : "Excluir quadro"}
+            </Button>
+            <div className="flex gap-2">
+              <Button type="button" variant="ghost" onClick={onClose}>
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                disabled={saving}
+                className="bg-red-600 hover:bg-red-700 text-white"
+              >
+                {saving ? "Salvando..." : "Salvar"}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-end/features/board/edit-list-dialog.tsx
+++ b/front-end/features/board/edit-list-dialog.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { editList } from "@/lib/actions/list";
+
+interface EditListDialogProps {
+  boardId: string;
+  listId: string | null;
+  currentTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function EditListDialog({
+  boardId,
+  listId,
+  currentTitle,
+  isOpen,
+  onClose,
+}: EditListDialogProps) {
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState(currentTitle);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setTitle(currentTitle);
+  }, [currentTitle, listId]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!listId || !title.trim()) return;
+    setLoading(true);
+    const result = await editList({ id: listId, title: title.trim() });
+    setLoading(false);
+    if (result.success) {
+      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      onClose();
+      toast.success("Lista renomeada");
+    } else {
+      toast.error(result.error || "Erro ao renomear lista");
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Renomear lista</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+          <div className="space-y-2">
+            <Label htmlFor="edit-list-title">Novo título</Label>
+            <Input
+              id="edit-list-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              autoFocus
+              required
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading}
+              className="bg-red-600 hover:bg-red-700 text-white"
+            >
+              {loading ? "Salvando..." : "Salvar"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-end/features/board/edit-task-dialog.tsx
+++ b/front-end/features/board/edit-task-dialog.tsx
@@ -71,7 +71,8 @@ export function EditTaskDialog({
       title: title.trim(),
       description: description.trim() || undefined,
       status,
-      dueDate: dueDate || undefined,
+      // datetime-local → ISO-8601 (Prisma exige)
+      dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
       assigneeId: canAssign ? (assigneeId !== UNASSIGNED ? assigneeId : null) : undefined,
     });
     setLoading(false);

--- a/front-end/features/board/edit-task-dialog.tsx
+++ b/front-end/features/board/edit-task-dialog.tsx
@@ -20,6 +20,7 @@ import {
 import { updateTask, deleteTask } from "@/lib/actions/task";
 import type { Task } from "../../types/task";
 import type { BoardMember } from "@/lib/actions/members";
+import { TaskHistory } from "@/features/board/task-history";
 
 interface EditTaskDialogProps {
   task: Task | null;
@@ -29,6 +30,8 @@ interface EditTaskDialogProps {
   members?: BoardMember[];
   canAssign?: boolean;
   canDelete?: boolean;
+  /** Admin/owner consegue ver histórico (TaskLogs) */
+  canViewHistory?: boolean;
 }
 
 const UNASSIGNED = "__unassigned__";
@@ -41,6 +44,7 @@ export function EditTaskDialog({
   members = [],
   canAssign = false,
   canDelete = false,
+  canViewHistory = false,
 }: EditTaskDialogProps) {
   const queryClient = useQueryClient();
   const [title, setTitle] = useState("");
@@ -174,6 +178,8 @@ export function EditTaskDialog({
               </Select>
             </div>
           )}
+
+          <TaskHistory taskId={task.id} enabled={canViewHistory} />
 
           <div className="flex justify-between gap-2 pt-2">
             {canDelete ? (

--- a/front-end/features/board/edit-task-dialog.tsx
+++ b/front-end/features/board/edit-task-dialog.tsx
@@ -21,6 +21,7 @@ import { updateTask, deleteTask } from "@/lib/actions/task";
 import type { Task } from "../../types/task";
 import type { BoardMember } from "@/lib/actions/members";
 import { TaskHistory } from "@/features/board/task-history";
+import { TaskLabelsPicker } from "@/features/board/task-labels-picker";
 
 interface EditTaskDialogProps {
   task: Task | null;
@@ -178,6 +179,12 @@ export function EditTaskDialog({
               </Select>
             </div>
           )}
+
+          <TaskLabelsPicker
+            taskId={task.id}
+            boardId={boardId}
+            currentLabels={task.labels ?? []}
+          />
 
           <TaskHistory taskId={task.id} enabled={canViewHistory} />
 

--- a/front-end/features/board/labels-dialog.tsx
+++ b/front-end/features/board/labels-dialog.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Plus, Trash2, Tag, Pencil, X, Check } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  getBoardLabels,
+  createLabel,
+  updateLabel,
+  deleteLabel,
+  type Label as BoardLabel,
+} from "@/lib/actions/labels";
+
+interface LabelsDialogProps {
+  boardId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  canManage?: boolean;
+}
+
+const PRESET_COLORS = [
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#06b6d4",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+  "#64748b",
+];
+
+export function LabelsDialog({ boardId, isOpen, onClose, canManage = false }: LabelsDialogProps) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [color, setColor] = useState(PRESET_COLORS[0]);
+  const [saving, setSaving] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editColor, setEditColor] = useState(PRESET_COLORS[0]);
+
+  const { data } = useQuery({
+    queryKey: ["board-labels", boardId],
+    queryFn: () => getBoardLabels(boardId),
+    enabled: isOpen && !!boardId,
+  });
+  const labels: BoardLabel[] = data?.success ? data.data : [];
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSaving(true);
+    const r = await createLabel(boardId, { name: name.trim(), color });
+    setSaving(false);
+    if (r.success) {
+      setName("");
+      setColor(PRESET_COLORS[0]);
+      queryClient.invalidateQueries({ queryKey: ["board-labels", boardId] });
+      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      toast.success("Label criada");
+    } else {
+      toast.error(r.error || "Erro ao criar label");
+    }
+  }
+
+  function startEdit(l: BoardLabel) {
+    setEditingId(l.id);
+    setEditName(l.name);
+    setEditColor(l.color);
+  }
+
+  async function saveEdit() {
+    if (!editingId || !editName.trim()) return;
+    const r = await updateLabel(editingId, { name: editName.trim(), color: editColor });
+    if (r.success) {
+      setEditingId(null);
+      queryClient.invalidateQueries({ queryKey: ["board-labels", boardId] });
+      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      toast.success("Label atualizada");
+    } else {
+      toast.error(r.error || "Erro ao atualizar");
+    }
+  }
+
+  async function handleDelete(id: string, n: string) {
+    if (!confirm(`Excluir a label "${n}"? Ela será removida de todas as tarefas.`)) return;
+    const r = await deleteLabel(id);
+    if (r.success) {
+      queryClient.invalidateQueries({ queryKey: ["board-labels", boardId] });
+      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      toast.success("Label excluída");
+    } else {
+      toast.error(r.error || "Erro ao excluir");
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Tag size={18} />
+            Labels do quadro
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 mt-2">
+          <div className="border border-[#E2E8F0] rounded-lg divide-y">
+            {labels.length === 0 ? (
+              <div className="p-4 text-sm text-[#94A3B8] text-center">
+                Nenhuma label ainda.
+              </div>
+            ) : (
+              labels.map((l) =>
+                editingId === l.id ? (
+                  <div key={l.id} className="p-3 space-y-2">
+                    <Input
+                      value={editName}
+                      onChange={(e) => setEditName(e.target.value)}
+                      autoFocus
+                    />
+                    <div className="flex flex-wrap gap-1.5">
+                      {PRESET_COLORS.map((c) => (
+                        <button
+                          key={c}
+                          type="button"
+                          onClick={() => setEditColor(c)}
+                          className={`w-6 h-6 rounded-full transition-transform ${
+                            editColor === c ? "ring-2 ring-offset-1 ring-red-600 scale-110" : ""
+                          }`}
+                          style={{ backgroundColor: c }}
+                          aria-label={`Cor ${c}`}
+                        />
+                      ))}
+                    </div>
+                    <div className="flex gap-2 justify-end">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setEditingId(null)}
+                      >
+                        <X size={14} />
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={saveEdit}
+                        className="bg-red-600 hover:bg-red-700 text-white"
+                      >
+                        <Check size={14} className="mr-1" />
+                        Salvar
+                      </Button>
+                    </div>
+                  </div>
+                ) : (
+                  <div key={l.id} className="flex items-center gap-2 p-2.5">
+                    <span
+                      className="w-4 h-4 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: l.color }}
+                    />
+                    <span className="flex-1 text-sm text-[#1E293B] truncate">{l.name}</span>
+                    {canManage && (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => startEdit(l)}
+                          className="p-1 text-[#94A3B8] hover:text-[#1E293B] transition-colors"
+                          aria-label="Editar"
+                        >
+                          <Pencil size={14} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(l.id, l.name)}
+                          className="p-1 text-[#94A3B8] hover:text-red-600 transition-colors"
+                          aria-label="Excluir"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      </>
+                    )}
+                  </div>
+                ),
+              )
+            )}
+          </div>
+
+          {canManage && (
+            <form onSubmit={handleCreate} className="border border-[#E2E8F0] rounded-lg p-3 space-y-2">
+              <div className="text-sm font-medium text-[#1E293B] flex items-center gap-1.5">
+                <Plus size={14} />
+                Nova label
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="label-name" className="sr-only">Nome</Label>
+                <Input
+                  id="label-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Ex: Bug, Feature, Urgente"
+                  maxLength={32}
+                  required
+                />
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {PRESET_COLORS.map((c) => (
+                  <button
+                    key={c}
+                    type="button"
+                    onClick={() => setColor(c)}
+                    className={`w-6 h-6 rounded-full transition-transform ${
+                      color === c ? "ring-2 ring-offset-1 ring-red-600 scale-110" : ""
+                    }`}
+                    style={{ backgroundColor: c }}
+                    aria-label={`Cor ${c}`}
+                  />
+                ))}
+              </div>
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  size="sm"
+                  disabled={saving}
+                  className="bg-red-600 hover:bg-red-700 text-white"
+                >
+                  {saving ? "Criando..." : "Criar label"}
+                </Button>
+              </div>
+            </form>
+          )}
+
+          <div className="flex justify-end">
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Fechar
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-end/features/board/task-card.tsx
+++ b/front-end/features/board/task-card.tsx
@@ -38,11 +38,23 @@ export function TaskCard({ task, members, onClick }: TaskCardProps) {
   const overdue = task.dueDate && new Date(task.dueDate).getTime() < Date.now();
   const badge = statusBadge[task.status] ?? statusBadge.TODO;
 
+  function handleKey(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  }
+
   return (
-    <button
-      type="button"
+    // div + role=button para que o pointerDown chegue limpo no Draggable
+    // (botões nativos podem capturar pointer events de forma diferente em
+    // alguns browsers, quebrando o início do drag).
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
-      className="w-full text-left rounded-lg border border-[#E2E8F0] bg-white p-3 shadow-sm hover:border-[#C01010]/40 hover:shadow transition-all"
+      onKeyDown={handleKey}
+      className="cursor-grab active:cursor-grabbing w-full text-left rounded-lg border border-[#E2E8F0] bg-white p-3 shadow-sm hover:border-[#C01010]/40 hover:shadow transition-all"
     >
       <div className="flex items-start justify-between gap-2">
         <p className="font-medium text-sm text-[#1E293B] line-clamp-2 flex-1">
@@ -87,6 +99,6 @@ export function TaskCard({ task, members, onClick }: TaskCardProps) {
           </div>
         )}
       </div>
-    </button>
+    </div>
   );
 }

--- a/front-end/features/board/task-card.tsx
+++ b/front-end/features/board/task-card.tsx
@@ -56,6 +56,22 @@ export function TaskCard({ task, members, onClick }: TaskCardProps) {
       onKeyDown={handleKey}
       className="cursor-grab active:cursor-grabbing w-full text-left rounded-lg border border-[#E2E8F0] bg-white p-3 shadow-sm hover:border-[#C01010]/40 hover:shadow transition-all"
     >
+      {task.labels && task.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-1.5">
+          {task.labels.map((tl) =>
+            tl.label ? (
+              <span
+                key={tl.labelId}
+                className="text-[10px] font-medium px-1.5 py-0.5 rounded-full text-white truncate max-w-[140px]"
+                style={{ backgroundColor: tl.label.color }}
+                title={tl.label.name}
+              >
+                {tl.label.name}
+              </span>
+            ) : null,
+          )}
+        </div>
+      )}
       <div className="flex items-start justify-between gap-2">
         <p className="font-medium text-sm text-[#1E293B] line-clamp-2 flex-1">
           {task.title}

--- a/front-end/features/board/task-history.tsx
+++ b/front-end/features/board/task-history.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Activity, Clock } from "lucide-react";
+
+import { getTaskLogs, type LogAction, type TaskLog } from "@/lib/actions/taskLogs";
+
+interface TaskHistoryProps {
+  taskId: string;
+  enabled: boolean;
+}
+
+function actionLabel(log: TaskLog): string {
+  const meta = log.metadata as Record<string, unknown> | undefined;
+  switch (log.action) {
+    case "TASK_CREATED":
+      return "criou a tarefa";
+    case "TASK_UPDATED":
+      return "editou os campos da tarefa";
+    case "TASK_STATUS_CHANGED": {
+      const from = (meta?.from as string) ?? "?";
+      const to = (meta?.to as string) ?? "?";
+      return `mudou o status de "${from}" para "${to}"`;
+    }
+    case "TASK_MOVED":
+      return "moveu a tarefa para outra lista";
+    case "TASK_ARCHIVED":
+      return "arquivou a tarefa";
+    case "TASK_DELETED":
+      return "excluiu a tarefa";
+    default:
+      return log.action;
+  }
+}
+
+function formatDate(d: string) {
+  try {
+    const date = new Date(d);
+    return date.toLocaleString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return d;
+  }
+}
+
+const actionIconColor: Record<LogAction, string> = {
+  TASK_CREATED: "bg-emerald-100 text-emerald-700",
+  TASK_UPDATED: "bg-slate-100 text-slate-700",
+  TASK_STATUS_CHANGED: "bg-amber-100 text-amber-700",
+  TASK_MOVED: "bg-blue-100 text-blue-700",
+  TASK_ARCHIVED: "bg-zinc-100 text-zinc-600",
+  TASK_DELETED: "bg-red-100 text-red-700",
+};
+
+export function TaskHistory({ taskId, enabled }: TaskHistoryProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["task-logs", taskId],
+    queryFn: () => getTaskLogs(taskId),
+    enabled: enabled && !!taskId,
+    staleTime: 30_000,
+  });
+
+  if (!enabled) return null;
+
+  const logs: TaskLog[] = data?.success ? data.data : [];
+
+  return (
+    <div className="mt-4 border-t border-[#E2E8F0] pt-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Activity size={14} className="text-[#94A3B8]" />
+        <h4 className="text-xs font-semibold text-[#64748B] uppercase tracking-wide">
+          Histórico
+        </h4>
+      </div>
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="h-10 bg-[#F1F5F9] rounded animate-pulse" />
+          ))}
+        </div>
+      ) : logs.length === 0 ? (
+        <p className="text-xs text-[#94A3B8] italic">Sem histórico registrado.</p>
+      ) : (
+        <ol className="space-y-2 max-h-64 overflow-y-auto pr-1">
+          {logs.map((log) => (
+            <li key={log.id} className="flex items-start gap-2 text-xs">
+              <span
+                className={`flex-shrink-0 w-6 h-6 rounded-full flex items-center justify-center ${actionIconColor[log.action]}`}
+              >
+                <Clock size={11} />
+              </span>
+              <div className="flex-1 min-w-0">
+                <p className="text-[#1E293B]">
+                  <strong>{log.user.name || log.user.email || "Usuário"}</strong>{" "}
+                  {actionLabel(log)}
+                </p>
+                <p className="text-[#94A3B8] mt-0.5">{formatDate(log.createdAt)}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/front-end/features/board/task-labels-picker.tsx
+++ b/front-end/features/board/task-labels-picker.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Tag, Plus, Check } from "lucide-react";
+
+import { Label as UiLabel } from "@/components/ui/label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  getBoardLabels,
+  addLabelToTask,
+  removeLabelFromTask,
+  type Label,
+} from "@/lib/actions/labels";
+import type { TaskLabelLink } from "../../types/task";
+
+interface TaskLabelsPickerProps {
+  taskId: string;
+  boardId: string;
+  currentLabels: TaskLabelLink[];
+}
+
+export function TaskLabelsPicker({ taskId, boardId, currentLabels }: TaskLabelsPickerProps) {
+  const queryClient = useQueryClient();
+  const [busy, setBusy] = useState(false);
+
+  const { data } = useQuery({
+    queryKey: ["board-labels", boardId],
+    queryFn: () => getBoardLabels(boardId),
+    enabled: !!boardId,
+  });
+  const allLabels: Label[] = data?.success ? data.data : [];
+
+  const assignedIds = new Set(currentLabels.map((l) => l.labelId));
+
+  async function toggle(label: Label) {
+    setBusy(true);
+    const r = assignedIds.has(label.id)
+      ? await removeLabelFromTask(taskId, label.id)
+      : await addLabelToTask(taskId, label.id);
+    setBusy(false);
+    if (r.success) {
+      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+    } else {
+      toast.error(r.error || "Erro ao atualizar labels");
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <UiLabel className="flex items-center gap-1.5">
+        <Tag size={14} />
+        Labels
+      </UiLabel>
+      <div className="flex flex-wrap gap-1.5 items-center">
+        {currentLabels.map((tl) =>
+          tl.label ? (
+            <span
+              key={tl.labelId}
+              className="text-xs px-2 py-0.5 rounded-full text-white"
+              style={{ backgroundColor: tl.label.color }}
+            >
+              {tl.label.name}
+            </span>
+          ) : null,
+        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              disabled={busy || allLabels.length === 0}
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full border border-dashed border-[#CBD5E1] text-[#64748B] hover:border-[#C01010] hover:text-[#C01010] transition-colors disabled:opacity-50"
+            >
+              <Plus size={12} />
+              {currentLabels.length === 0 ? "Adicionar label" : "Editar"}
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-56">
+            {allLabels.length === 0 ? (
+              <div className="p-3 text-xs text-[#94A3B8]">
+                Nenhuma label criada ainda no board.
+              </div>
+            ) : (
+              allLabels.map((l) => {
+                const assigned = assignedIds.has(l.id);
+                return (
+                  <DropdownMenuItem
+                    key={l.id}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      toggle(l);
+                    }}
+                    className="gap-2"
+                  >
+                    <span
+                      className="w-3 h-3 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: l.color }}
+                    />
+                    <span className="flex-1 truncate">{l.name}</span>
+                    {assigned && <Check size={14} className="text-[#C01010]" />}
+                  </DropdownMenuItem>
+                );
+              })
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  );
+}

--- a/front-end/features/dashboard/pending-tasks.tsx
+++ b/front-end/features/dashboard/pending-tasks.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { AlertTriangle, Calendar, Clock } from "lucide-react";
+
+import { getExpiredTasks } from "@/lib/actions/task";
+
+interface ExpiredTaskAPI {
+  id: string;
+  title: string;
+  status: string;
+  dueDate?: string | null;
+  listId: string;
+  list?: {
+    id: string;
+    title: string;
+    board?: {
+      id: string;
+      title: string;
+    };
+  };
+  assignee?: {
+    id: string;
+    name: string | null;
+    email?: string | null;
+  } | null;
+}
+
+function formatDue(dateStr?: string | null) {
+  if (!dateStr) return null;
+  const d = new Date(dateStr);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function PendingTasks() {
+  const router = useRouter();
+  const { data, isLoading } = useQuery({
+    queryKey: ["expired-tasks"],
+    queryFn: getExpiredTasks,
+    refetchInterval: 60_000, // re-poll a cada 60s
+  });
+
+  const tasks: ExpiredTaskAPI[] = (data?.success ? data.data : []) as ExpiredTaskAPI[];
+
+  if (isLoading) {
+    return (
+      <div className="rounded-xl bg-white shadow-sm border border-[#E2E8F0] p-6 mb-6">
+        <div className="h-5 w-32 bg-[#F1F5F9] rounded animate-pulse" />
+        <div className="space-y-2 mt-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="h-12 bg-[#F1F5F9] rounded animate-pulse" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-xl bg-white shadow-sm border border-[#E2E8F0] overflow-hidden mb-6">
+      <div className="px-6 py-4 border-b border-[#E2E8F0] flex items-center gap-2">
+        <AlertTriangle size={18} className="text-amber-600" />
+        <h2 className="text-base font-semibold text-[#1E293B]">
+          Pendências ({tasks.length})
+        </h2>
+        <span className="text-xs text-[#94A3B8] ml-1">atrasadas ou vencendo em ≤12h</span>
+      </div>
+      <div className="divide-y divide-[#F1F5F9]">
+        {tasks.map((t) => {
+          const due = formatDue(t.dueDate);
+          const overdue =
+            t.dueDate && new Date(t.dueDate).getTime() < Date.now();
+          const boardId = t.list?.board?.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => boardId && router.push(`/dashboard/board/${boardId}`)}
+              className="w-full text-left flex items-center gap-3 px-6 py-3 hover:bg-[#FEF2F2]/30 transition-colors"
+            >
+              <div
+                className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                  overdue ? "bg-red-500" : "bg-amber-500"
+                }`}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-sm text-[#1E293B] truncate">{t.title}</p>
+                <div className="flex items-center gap-3 mt-0.5 text-xs text-[#94A3B8]">
+                  <span className="truncate">
+                    {t.list?.board?.title} / {t.list?.title}
+                  </span>
+                  {t.assignee?.name && (
+                    <span className="italic">· {t.assignee.name}</span>
+                  )}
+                </div>
+              </div>
+              <div
+                className={`flex items-center gap-1 text-xs flex-shrink-0 ${
+                  overdue ? "text-red-600 font-medium" : "text-amber-700"
+                }`}
+              >
+                {overdue ? <AlertTriangle size={12} /> : <Clock size={12} />}
+                {due ? (
+                  <span>{due}</span>
+                ) : (
+                  <span className="flex items-center gap-1">
+                    <Calendar size={11} />—
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front-end/lib/actions/board.ts
+++ b/front-end/lib/actions/board.ts
@@ -43,6 +43,22 @@ export async function getBoards() {
   }
 }
 
+export async function updateBoard(
+  boardId: string,
+  data: { title?: string; description?: string },
+) {
+  try {
+    const safeBoardId = validateId(boardId, 'boardId');
+    await api.patch(`/v1/boards/${safeBoardId}`, data);
+    return { success: true as const, data: { message: 'success' } };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao atualizar o board"),
+    };
+  }
+}
+
 export async function deleteBoard(boardId: string) {
   try {
     const safeBoardId = validateId(boardId, 'boardId');

--- a/front-end/lib/actions/labels.ts
+++ b/front-end/lib/actions/labels.ts
@@ -1,0 +1,104 @@
+'use server';
+
+import api from "@/lib/api/axios";
+import { handleAxiosError } from "@/lib/utils/handle-axios-error";
+import { validateId } from "@/lib/utils/validateId";
+
+export interface Label {
+  id: string;
+  boardId: string;
+  name: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function getBoardLabels(boardId: string) {
+  try {
+    const safeId = validateId(boardId, 'boardId');
+    const response = await api.get(`/v1/boards/${safeId}/labels`);
+    return { success: true as const, data: response.data as Label[] };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao buscar labels"),
+    };
+  }
+}
+
+export async function createLabel(
+  boardId: string,
+  data: { name: string; color: string },
+) {
+  try {
+    const safeId = validateId(boardId, 'boardId');
+    const response = await api.post(`/v1/boards/${safeId}/labels`, data);
+    return { success: true as const, data: response.data as Label };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao criar label"),
+    };
+  }
+}
+
+export async function updateLabel(
+  labelId: string,
+  data: { name?: string; color?: string },
+) {
+  try {
+    const safeId = validateId(labelId, 'labelId');
+    const response = await api.patch(`/v1/labels/${safeId}`, data);
+    return { success: true as const, data: response.data as Label };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao atualizar label"),
+    };
+  }
+}
+
+export async function deleteLabel(labelId: string) {
+  try {
+    const safeId = validateId(labelId, 'labelId');
+    const response = await api.delete(`/v1/labels/${safeId}`);
+    return { success: true as const, data: response.data };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao remover label"),
+    };
+  }
+}
+
+export async function addLabelToTask(taskId: string, labelId: string) {
+  try {
+    const safeTaskId = validateId(taskId, 'taskId');
+    const safeLabelId = validateId(labelId, 'labelId');
+    const response = await api.post(
+      `/v1/tasks/${safeTaskId}/labels/${safeLabelId}`,
+    );
+    return { success: true as const, data: response.data };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao atribuir label"),
+    };
+  }
+}
+
+export async function removeLabelFromTask(taskId: string, labelId: string) {
+  try {
+    const safeTaskId = validateId(taskId, 'taskId');
+    const safeLabelId = validateId(labelId, 'labelId');
+    const response = await api.delete(
+      `/v1/tasks/${safeTaskId}/labels/${safeLabelId}`,
+    );
+    return { success: true as const, data: response.data };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao remover label"),
+    };
+  }
+}

--- a/front-end/lib/actions/members.ts
+++ b/front-end/lib/actions/members.ts
@@ -88,7 +88,14 @@ export async function getMyRoleOnBoard(boardId: string) {
   try {
     const safeId = validateId(boardId, 'boardId');
     const response = await api.get(`/v1/boards/${safeId}/my-role`);
-    return { success: true as const, data: response.data as { role: MyRole } };
+    // Backend retorna a role como string ("OWNER" | "ADMIN" | ...) ou null.
+    // Normaliza para { role } pra ficar consistente no consumo.
+    const raw = response.data as MyRole | { role: MyRole } | null;
+    const role: MyRole =
+      raw && typeof raw === 'object' && 'role' in raw
+        ? (raw.role as MyRole)
+        : (raw as MyRole);
+    return { success: true as const, data: { role } };
   } catch (error) {
     return {
       success: false as const,

--- a/front-end/lib/actions/notifications.ts
+++ b/front-end/lib/actions/notifications.ts
@@ -1,0 +1,57 @@
+'use server';
+
+import api from "@/lib/api/axios";
+import { handleAxiosError } from "@/lib/utils/handle-axios-error";
+import { validateId } from "@/lib/utils/validateId";
+
+export type InviteStatus = 'PENDING' | 'ACCEPTED' | 'DECLINED';
+
+export interface InviteNotification {
+  id: string;
+  createdAt: string;
+  statusInvite: InviteStatus;
+  role: 'ADMIN' | 'MEMBER' | 'OBSERVER';
+  sender: {
+    id: string;
+    name: string | null;
+    userName: string | null;
+  };
+  board: {
+    id: string;
+    title: string;
+  };
+}
+
+export async function getNotifications() {
+  try {
+    const response = await api.get('/v1/me/notifications');
+    const data = response.data as InviteNotification[];
+    return { success: true as const, data };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao buscar notificações"),
+    };
+  }
+}
+
+export async function respondInvite(
+  boardId: string,
+  idInvite: string,
+  accept: boolean,
+) {
+  try {
+    const safeBoardId = validateId(boardId, 'boardId');
+    const safeInviteId = validateId(idInvite, 'idInvite');
+    const response = await api.post(
+      `/v1/boards/invite/${safeBoardId}/response`,
+      { idInvite: safeInviteId, response: accept },
+    );
+    return { success: true as const, data: response.data };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao responder convite"),
+    };
+  }
+}

--- a/front-end/lib/actions/taskLogs.ts
+++ b/front-end/lib/actions/taskLogs.ts
@@ -1,0 +1,38 @@
+'use server';
+
+import api from "@/lib/api/axios";
+import { handleAxiosError } from "@/lib/utils/handle-axios-error";
+import { validateId } from "@/lib/utils/validateId";
+
+export type LogAction =
+  | 'TASK_CREATED'
+  | 'TASK_UPDATED'
+  | 'TASK_MOVED'
+  | 'TASK_STATUS_CHANGED'
+  | 'TASK_ARCHIVED'
+  | 'TASK_DELETED';
+
+export interface TaskLog {
+  id: string;
+  action: LogAction;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+  };
+}
+
+export async function getTaskLogs(taskId: string) {
+  try {
+    const safeTaskId = validateId(taskId, 'taskId');
+    const response = await api.get(`/v1/task-logs/${safeTaskId}`);
+    return { success: true as const, data: response.data as TaskLog[] };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Falha ao buscar histórico da tarefa"),
+    };
+  }
+}

--- a/front-end/providers.tsx
+++ b/front-end/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { ReactNode, useState } from "react";
 
 export default function Providers({ children }: { children: ReactNode }) {
@@ -22,8 +23,15 @@ export default function Providers({ children }: { children: ReactNode }) {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-    </QueryClientProvider>
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/front-end/providers.tsx
+++ b/front-end/providers.tsx
@@ -1,11 +1,26 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactNode } from "react";
-
-const queryClient = new QueryClient();
+import { ReactNode, useState } from "react";
 
 export default function Providers({ children }: { children: ReactNode }) {
+  // Stable QueryClient (Pattern recomendado do react-query pra Next.js).
+  // Sem useState, o QueryClient pode ser recriado em re-renders ou
+  // double-mounts do React Strict Mode em dev, perdendo cache e
+  // causando refetches em loop.
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: 1,
+            staleTime: 30_000,
+          },
+        },
+      }),
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       {children}

--- a/front-end/types/task.ts
+++ b/front-end/types/task.ts
@@ -19,6 +19,16 @@ export interface UpdateTaskData {
   assigneeId?: string | null;
 }
 
+export interface TaskLabelLink {
+  labelId: string;
+  taskId: string;
+  label?: {
+    id: string;
+    name: string;
+    color: string;
+  };
+}
+
 export interface Task {
   id: string;
   listId: string;
@@ -31,6 +41,7 @@ export interface Task {
   updatedAt: string;
   priority?: Priority;
   assigneeId?: string | null;
+  labels?: TaskLabelLink[];
 }
 
 export type Priority = 'HIGH' | 'MEDIUM' | 'LOW';


### PR DESCRIPTION
## Summary

O front esperava `{ role: ... }` do endpoint `GET /v1/boards/:id/my-role` mas o backend retorna a role como string direta. Isso fazia `isAdmin = false` mesmo pra o owner, escondendo todos os botões de criar lista/card na Kanban.

Validado em ambiente local: owner agora vê os botões e consegue criar listas/cards/atribuir membros.

## Changes

- `lib/actions/members.ts`: normaliza a resposta do `my-role` aceitando tanto string solta quanto `{ role }`

## Test plan
- [x] Login → criar board → entrar no board → ver botões "Membros" e "Nova lista"
- [x] Empty state aparece quando não há listas

## Pendências (próximos PRs)
- Loop infinito de `GET /v1/me/profile` no dashboard (não bloqueia)
- Drag-and-drop de cards entre listas
- Wireup das telas `/dashboard/backlog` e `/dashboard/sprints`