### PR TITLE
chore: gitignore p/ duplicatas iCloud + pasta scrap/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,19 @@ back-end/test-results
 /package.json
 /package-lock.json
 .claude
+# ----------------------
+# Limpeza iCloud sync
+# ----------------------
+# Pasta de WIP sem dono (movida pra cá em vez de deletar)
+scrap/
+
+# Duplicatas que o iCloud cria (' 2.ext', ' 3.ext')
+* [0-9].ts
+* [0-9].tsx
+* [0-9].json
+* [0-9].yml
+* [0-9].yaml
+* [0-9].mjs
+* [0-9].css
+* [0-9].md
+.semgrepignore[ 0-9]*


### PR DESCRIPTION
## Por quê

iCloud Drive (sync do `~/Desktop/`) restaura arquivos deletados como duplicatas com sufixo ` N.ext` (ex: `backlog.service 2.ts`, `middleware 2.ts`). Isso recriou módulos que tínhamos removido em PRs anteriores e travou o build do back (10 erros TS sobre `Property 'backlog' does not exist`).

## O que muda

`.gitignore`:
- Pasta `scrap/` — destino de WIP sem dono que apareceu via iCloud mas ninguém importa (`lib/contexts/`, `lib/hooks/`, `lib/socket/` ficaram lá em vez de deletar).
- Padrões para arquivos que iCloud duplica: `*.ts`, `*.tsx`, `*.json`, `*.yml`, `*.yaml`, `*.mjs`, `*.css`, `*.md` com sufixo ` N`.
- `.semgrepignore[ N]`

## Limitação

Isto não impede o iCloud de **criar** os arquivos no disco — apenas mantém o `git status` limpo. A solução de raiz é mover o repo pra fora do `~/Desktop/` (ou desativar iCloud Drive sync nessa pasta). Está como item de discussão.

## Test plan

- [x] `git status` limpo após pull
- [x] Build do back não quebra após iCloud recriar duplicatas