### PR TITLE
fix: overflow modal de membros + trocar board não navega

### DIFF
--- a/front-end/components/layout/sidebar/board-select.tsx
+++ b/front-end/components/layout/sidebar/board-select.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -9,6 +10,8 @@ import { CreateBoardDialog } from "../../../features/board/create-board-dialog";
 import { useBoardStore } from "@/stores/use-board-store";
 
 export const BoardSelect = () => {
+  const router = useRouter();
+  const pathname = usePathname();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { selectedBoardId, setSelectedBoardId } = useBoardStore();
 
@@ -17,9 +20,21 @@ export const BoardSelect = () => {
     queryFn: getBoards
   });
 
+  /**
+   * Atualiza o store e navega quando a rota depende do boardId na URL.
+   * Sem isso, o store muda mas /dashboard/board/[id] continua mostrando
+   * o board antigo (id vem de params).
+   */
+  function handleChange(id: string) {
+    setSelectedBoardId(id);
+    if (pathname.startsWith("/dashboard/board/")) {
+      router.push(`/dashboard/board/${id}`);
+    }
+  }
+
   return (
     <>
-      <Select value={selectedBoardId || ""} onValueChange={setSelectedBoardId}>
+      <Select value={selectedBoardId || ""} onValueChange={handleChange}>
         <SelectTrigger className="w-full h-full">
           <SelectValue placeholder="Choose your Board" />
         </SelectTrigger>

--- a/front-end/features/board/members-dialog.tsx
+++ b/front-end/features/board/members-dialog.tsx
@@ -92,7 +92,7 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
 
   return (
     <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-xl w-[calc(100vw-2rem)] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Membros do quadro</DialogTitle>
         </DialogHeader>
@@ -108,7 +108,7 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
                 const name = m.user.name || m.user.userName || m.user.email || m.userId;
                 return (
                   <div key={m.userId} className="flex items-center gap-3 p-3">
-                    <div className="w-9 h-9 rounded-full bg-red-100 dark:bg-red-950/40 flex items-center justify-center text-red-600 dark:text-red-400 font-semibold">
+                    <div className="w-9 h-9 rounded-full bg-red-100 dark:bg-red-950/40 flex items-center justify-center text-red-600 dark:text-red-400 font-semibold flex-shrink-0">
                       {(name[0] || "?").toUpperCase()}
                     </div>
                     <div className="flex-1 min-w-0">
@@ -120,7 +120,7 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
                         value={m.role}
                         onValueChange={(v) => handleChangeRole(m.userId, v as Role)}
                       >
-                        <SelectTrigger className="w-36">
+                        <SelectTrigger className="w-32 sm:w-36 flex-shrink-0">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -130,7 +130,7 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
                         </SelectContent>
                       </Select>
                     ) : (
-                      <span className="text-xs px-2 py-1 rounded bg-muted text-muted-foreground">
+                      <span className="text-xs px-2 py-1 rounded bg-muted text-muted-foreground flex-shrink-0">
                         {roleLabel[m.role]}
                       </span>
                     )}
@@ -140,7 +140,7 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
                         variant="ghost"
                         size="icon"
                         onClick={() => handleRemove(m.userId, name)}
-                        className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                        className="text-red-600 hover:text-red-700 hover:bg-red-50 flex-shrink-0"
                         title="Remover membro"
                       >
                         <Trash2 size={16} />


### PR DESCRIPTION
## Bug 1 — Modal 'Membros do quadro' cortado

Em viewport menor, o nome do usuário + Select de role (`w-36` fixo) + botão lixeira não cabiam em `max-w-2xl` e estouravam pra fora. Lixeira e botão 'Fechar' apareciam fora do dialog.

**Fix:** 
- `max-w-xl w-[calc(100vw-2rem)] max-h-[90vh] overflow-y-auto` no `DialogContent` — responsivo + cabe sempre na viewport
- `flex-shrink-0` em avatar, Select de role, Badge e botão lixeira — esses não somem mais quando o nome do usuário é longo
- Select responsivo: `w-32 sm:w-36` (mais compacto em mobile)

## Bug 2 — Trocar board no Select não muda a tela

`/dashboard/board/[id]` lê o boardId de `params.id` da URL. O `BoardSelect` chamava `setSelectedBoardId` (zustand) mas **não fazia push**, então o store mudava e a página continuava no board antigo.

**Fix:** `handleChange` agora também faz `router.push('/dashboard/board/${id}')` quando `pathname.startsWith('/dashboard/board/')`. Outras rotas (sprints, backlog) só atualizam o store.

## Test plan

- [x] Modal: abrir com pelo menos 1 nome longo + viewport ~1280px → lixeira e Select visíveis
- [x] Modal: redimensionar até ~600px → conteúdo continua acessível (scroll vertical se preciso)
- [x] BoardSelect: estar em `/dashboard/board/[id]`, trocar de board no Select → URL muda e tela mostra board novo
- [x] BoardSelect: estar em `/dashboard/sprints` ou `/dashboard/backlog`, trocar de board → store muda, página reage (lista de sprints/tasks atualiza)