### PR TITLE
feat: status BLOCKED (impedido) — 4ª coluna no kanban da Sprint

### DIFF
--- a/back-end/prisma/migrations/20260515211020_add_blocked_status/migration.sql
+++ b/back-end/prisma/migrations/20260515211020_add_blocked_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."Status" ADD VALUE 'BLOCKED';

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -226,6 +226,7 @@ enum BoardVisibility {
 enum Status {
   TODO
   IN_PROGRESS
+  BLOCKED
   DONE
   ARCHIVED
 }

--- a/back-end/src/common/enums/task-status.enum.ts
+++ b/back-end/src/common/enums/task-status.enum.ts
@@ -1,6 +1,7 @@
 export enum TaskStatus {
   TODO = 'TODO',
   IN_PROGRESS = 'IN_PROGRESS',
+  BLOCKED = 'BLOCKED',
   DONE = 'DONE',
   ARCHIVED = 'ARCHIVED',
 }

--- a/front-end/app/dashboard/backlog/page.tsx
+++ b/front-end/app/dashboard/backlog/page.tsx
@@ -11,12 +11,13 @@ import { DataTable } from "@/features/backlog/components/data-table";
 import { getBacklogColumns } from "@/features/backlog/components/columns";
 import { getMyTasks } from "@/lib/actions/backlog";
 
-type StatusFilter = "ALL" | "TODO" | "IN_PROGRESS" | "DONE" | "ARCHIVED";
+type StatusFilter = "ALL" | "TODO" | "IN_PROGRESS" | "BLOCKED" | "DONE" | "ARCHIVED";
 
 const STATUS_OPTIONS: { value: StatusFilter; label: string; className: string }[] = [
   { value: "ALL", label: "Todos", className: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200" },
   { value: "TODO", label: "A fazer", className: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200" },
   { value: "IN_PROGRESS", label: "Em progresso", className: "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300" },
+  { value: "BLOCKED", label: "Impedido", className: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300" },
   { value: "DONE", label: "Concluído", className: "bg-emerald-100 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300" },
   { value: "ARCHIVED", label: "Arquivada", className: "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300" },
 ];

--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -401,6 +401,7 @@ export default function BoardPage() {
             { value: "__all__", label: "Todos", className: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200" },
             { value: "TODO", label: "A fazer", className: "bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200" },
             { value: "IN_PROGRESS", label: "Em progresso", className: "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300" },
+            { value: "BLOCKED", label: "Impedido", className: "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300" },
             { value: "DONE", label: "Concluído", className: "bg-emerald-100 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300" },
           ].map((opt) => {
             const active = statusFilter === opt.value;

--- a/front-end/app/dashboard/sprints/page.tsx
+++ b/front-end/app/dashboard/sprints/page.tsx
@@ -26,7 +26,7 @@ import {
 import { CreateSprintDialog } from "@/features/sprints/create-sprint-dialog";
 import { AddTaskDialog } from "@/features/sprints/add-task-dialog";
 
-type Bucket = "TODO" | "IN_PROGRESS" | "DONE";
+type Bucket = "TODO" | "IN_PROGRESS" | "BLOCKED" | "DONE";
 
 const BUCKETS: { key: Bucket; label: string; className: string }[] = [
   {
@@ -40,6 +40,12 @@ const BUCKETS: { key: Bucket; label: string; className: string }[] = [
     label: "Em progresso",
     className:
       "bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300",
+  },
+  {
+    key: "BLOCKED",
+    label: "Impedido",
+    className:
+      "bg-red-100 dark:bg-red-950/40 text-red-700 dark:text-red-300",
   },
   {
     key: "DONE",
@@ -81,6 +87,7 @@ export default function SprintsPage() {
     const out: Record<Bucket, SprintTask[]> = {
       TODO: [],
       IN_PROGRESS: [],
+      BLOCKED: [],
       DONE: [],
     };
     if (!sprint) return out;
@@ -242,7 +249,7 @@ export default function SprintsPage() {
       </div>
 
       {/* Kanban */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
         {BUCKETS.map((bucket) => {
           const tasks = grouped[bucket.key];
           return (

--- a/front-end/features/backlog/components/columns.tsx
+++ b/front-end/features/backlog/components/columns.tsx
@@ -11,6 +11,7 @@ const getStatusConfig = (status: string) => {
   const s = status?.toUpperCase() || "";
   if (s === "TODO") return { color: "bg-slate-400 dark:bg-slate-500", text: "A fazer" };
   if (s === "IN_PROGRESS") return { color: "bg-amber-500", text: "Em progresso" };
+  if (s === "BLOCKED") return { color: "bg-red-500", text: "Impedido" };
   if (s === "DONE") return { color: "bg-emerald-500", text: "Concluído" };
   if (s === "ARCHIVED") return { color: "bg-zinc-400 dark:bg-zinc-500", text: "Arquivada" };
   return { color: "bg-muted-foreground/40", text: status };

--- a/front-end/features/board/edit-task-dialog.tsx
+++ b/front-end/features/board/edit-task-dialog.tsx
@@ -147,6 +147,7 @@ export function EditTaskDialog({
                 <SelectContent>
                   <SelectItem value="TODO">A fazer</SelectItem>
                   <SelectItem value="IN_PROGRESS">Em progresso</SelectItem>
+                  <SelectItem value="BLOCKED">Impedido</SelectItem>
                   <SelectItem value="DONE">Concluído</SelectItem>
                   <SelectItem value="ARCHIVED">Arquivada</SelectItem>
                 </SelectContent>

--- a/front-end/features/board/task-card.tsx
+++ b/front-end/features/board/task-card.tsx
@@ -26,6 +26,7 @@ function formatDue(dateStr?: string) {
 const statusBadge: Record<string, { label: string; className: string }> = {
   TODO: { label: "A fazer", className: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200" },
   IN_PROGRESS: { label: "Em progresso", className: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300" },
+  BLOCKED: { label: "Impedido", className: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-300" },
   DONE: { label: "Concluído", className: "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300" },
   ARCHIVED: { label: "Arquivada", className: "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400" },
 };


### PR DESCRIPTION
## Por quê

Pedido pelo PO: time precisa sinalizar quando uma task está **impedida de avançar**. A issue #155 desenhava como flag `isBlocked` ortogonal ao status (mais sofisticado, mas precisaria de UI separada e schema novo). Em conversa com PO, decidimos abordagem mais simples e visual: **adicionar `BLOCKED` como valor do enum `Status`**, virando a 4ª coluna no kanban da Sprint.

Trade-off aceito:
- ❌ Perde a ortogonalidade — uma task `IN_PROGRESS` e bloqueada vira `BLOCKED` (perde o status anterior, não dá pra desbloquear "voltar pro IN_PROGRESS automaticamente")
- ✅ Migration trivial (`ADD VALUE`), UI mínima (4ª coluna), comportamento visual claro pro time

## O que muda

**Backend**
- `enum Status` no Prisma e `TaskStatus` enum TS ganham `BLOCKED` (entre `IN_PROGRESS` e `DONE`).
- Migration `20260515211020_add_blocked_status` — só `ALTER TYPE ADD VALUE`, idempotente em tabelas existentes.

**Frontend**
- `/dashboard/sprints` — kanban com 4 colunas (TODO → IN_PROGRESS → IMPEDIDO → CONCLUÍDO). Grid responsivo: 1 col mobile, 2 tablet, 4 desktop.
- `/dashboard/board/[id]` — filtro de status no toolbar ganha pílula "Impedido".
- `/dashboard/backlog` — idem no filtro.
- `EditTaskDialog` — Select de status ganha opção "Impedido".
- `TaskCard` no board + `columns.tsx` no backlog — cor vermelha (`bg-red-100 dark:bg-red-950/40 text-red-700`) pra status BLOCKED.

## Impacto na issue #155

A #155 (flag `isBlocked` + `blockedReason` + log) fica **obsoleta** com essa abordagem. Sugestão: fechar #155 com comentário linkando este PR quando mergear, ou reescrever pra focar só em "razão do bloqueio" (`blockedReason String?` independente do status) — pode entrar como melhoria futura, mas não é blocker do sprint atual.

## Test plan

- [x] Migrate: `prisma migrate deploy` aplica sem erro em DB com tasks existentes
- [x] Sprint: criar task → "Adicionar à sprint" → mudar status pra Impedido no EditTaskDialog → aparece na 4ª coluna
- [x] Board: filtrar por "Impedido" → mostra só tasks BLOCKED
- [x] Backlog: idem
- [x] Dark mode: coluna BLOCKED com contraste correto
- [x] Mobile/tablet: grid 1/2 colunas renderiza ok