### PR TITLE
fix: members-dialog ainda cortado em viewport >=640px

### DIFF
--- a/front-end/features/board/members-dialog.tsx
+++ b/front-end/features/board/members-dialog.tsx
@@ -92,7 +92,11 @@ export function MembersDialog({ boardId, isOpen, onClose, canManage = false }: M
 
   return (
     <Dialog open={isOpen} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-xl w-[calc(100vw-2rem)] max-h-[90vh] overflow-y-auto">
+      {/* sm:max-w-xl em vez de só max-w-xl: o DialogContent do shadcn tem
+          sm:max-w-sm (384px) hardcoded como default. Sem o prefixo sm: aqui
+          esse default ganha em viewports >=640px e o conteúdo (avatar + nome
+          + Select role + lixeira) extrapola. */}
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-xl sm:max-w-xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Membros do quadro</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Bug

Follow-up do PR #157. Reportado pelo Gabriel com screenshot — modal "Membros do quadro" continuava cortado mesmo após o fix anterior.

## Causa raiz

O componente `DialogContent` do shadcn (`components/ui/dialog.tsx:64`) declara `sm:max-w-sm` (384px) como **default**. Quando eu passei `max-w-xl` (576px) na propriedade `className`, o `cn()`/tw-merge não removeu o `sm:max-w-sm` — tw-merge trata `sm:max-w-sm` e `max-w-xl` como classes de variantes responsivas diferentes e mantém as duas.

Resultado: em viewport >= 640px (breakpoint `sm:`), o `sm:max-w-sm` da base ganhava do `max-w-xl` que passei, voltando o dialog pra 384px. Conteúdo (avatar + nome + Select role + lixeira) extrapolava.

## Fix

Passar `sm:max-w-xl` explicitamente — agora há variante `sm:` na minha classe que tw-merge entende como conflito direto com `sm:max-w-sm` da base, e a do consumidor ganha.

```diff
- <DialogContent className="max-w-xl w-[calc(100vw-2rem)] max-h-[90vh] overflow-y-auto">
+ <DialogContent className="w-[calc(100vw-2rem)] max-w-xl sm:max-w-xl max-h-[90vh] overflow-y-auto">
```

Comentário no código documenta o gotcha pro futuro.

## Tech debt detectado (escopo separado)

Todos os outros dialogs do projeto passam só `max-w-*` (sem variante `sm:`):
- `create-task-dialog`, `edit-task-dialog`, `labels-dialog`, `create-list-dialog`, `edit-list-dialog`, `edit-board-dialog`, `create-board-dialog`, `create-sprint-dialog`, `add-task-dialog`

Funcionam por acaso porque o conteúdo cabe em 384px. Em viewport sm: estão **capados em 384px** sem ninguém perceber. Vale uma issue de cleanup futuro (passar todos pra `sm:max-w-*`).

## Test plan

- [x] Abrir modal "Membros" do board → lixeira aparece em todas as rows
- [x] Botão "Adicionar" e "Fechar" visíveis dentro do dialog
- [x] Viewport ~800px e ~1280px: ambos OK