### PR TITLE
fix: signin retornava 400 quando rememberMe não vinha do front

### DIFF
--- a/back-end/src/auth/dto/signin.dto.ts
+++ b/back-end/src/auth/dto/signin.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, IsBoolean } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class SignInDto {
   @ApiProperty({ example: 'username@gmail.com' })
@@ -13,7 +19,12 @@ export class SignInDto {
   @IsString({ message: 'senha deve ser uma string' })
   password!: string;
 
-  @ApiProperty({ example: true })
+  // `?` no TypeScript não faz a validação ser opcional — class-validator
+  // ainda exige boolean se o decorator @IsBoolean estiver presente.
+  // Sem @IsOptional, o front mandar undefined (checkbox não marcado)
+  // virava 400 "deve ser um booleano".
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
   @IsBoolean({ message: 'deve ser um booleano' })
   rememberMe?: boolean;
 }


### PR DESCRIPTION
## Bug

Reportado em demo durante reunião — login retornava erro ao tentar entrar.

`POST /v1/auth/signin` respondia **400** com mensagem \`\"deve ser um booleano\"\` mesmo com credenciais válidas, quando o usuário **não marcava** o checkbox 'Lembrar de mim'.

## Causa raiz

\`signin.dto.ts\` declarava:

\`\`\`ts
@IsBoolean({ message: 'deve ser um booleano' })
rememberMe?: boolean;
\`\`\`

O \`?\` é só TypeScript — class-validator não considera. Quando o front mandava \`undefined\` (checkbox não marcado), o \`@IsBoolean\` rejeitava porque \`undefined\` não é boolean.

## Fix

Adicionar \`@IsOptional()\` antes do \`@IsBoolean()\`. Bonus: \`ApiProperty\` → \`ApiPropertyOptional\` pra semântica correta no Swagger. Comentário no código documenta o gotcha pro futuro.

## Test plan

- [ ] \`curl -X POST /v1/auth/signin\` SEM rememberMe → 401 (credenciais), não 400
- [ ] Tela de login: submeter sem marcar 'Lembrar de mim' → entra ou mostra erro real de credencial
- [ ] Tela de login: marcar 'Lembrar de mim' + entrar → entra normalmente

## Tempo até hotfix

Identificado durante demo, fix < 2min. Recomendo merge rápido pra desbloquear demos.