### PR TITLE
fix: ciclo logout → login travava (signin DTO + hard reload no logout)

### DIFF
--- a/back-end/src/auth/dto/signin.dto.ts
+++ b/back-end/src/auth/dto/signin.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsNotEmpty, IsString, IsBoolean } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class SignInDto {
   @ApiProperty({ example: 'username@gmail.com' })
@@ -13,7 +19,12 @@ export class SignInDto {
   @IsString({ message: 'senha deve ser uma string' })
   password!: string;
 
-  @ApiProperty({ example: true })
+  // `?` no TypeScript não faz a validação ser opcional — class-validator
+  // ainda exige boolean se o decorator @IsBoolean estiver presente.
+  // Sem @IsOptional, o front mandar undefined (checkbox não marcado)
+  // virava 400 "deve ser um booleano".
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
   @IsBoolean({ message: 'deve ser um booleano' })
   rememberMe?: boolean;
 }

--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -43,7 +43,11 @@ export default function Header() {
 
   const handleLogout = async () => {
     await removeCookie("sprinttacker-session");
-    router.push("/auth/login/");
+    // window.location em vez de router.push: hard reload limpa o cache do
+    // react-query e desmonta todos os componentes/forms do dashboard. Sem
+    // isso, queries em flight com cookie já apagado podem deixar estado
+    // sujo e travar o próximo submit de login.
+    window.location.href = "/auth/login";
   };
 
   return (


### PR DESCRIPTION
## Bug reportado em demo

Após logar com sucesso, fazer logout e tentar logar de novo, "clico em Entrar e não faz nada".

## Causa raiz (dois bugs encadeados)

### 1. `signin.dto.ts` — `rememberMe` exigia boolean mesmo quando undefined

Já documentado no PR #161 (estou substituindo aquele PR com este, que junta os 2 fixes correlatos). O front mandava `undefined` quando checkbox não marcado → `@IsBoolean()` rejeitava → 400 "deve ser um booleano".

### 2. `handleLogout` em `header/index.tsx` — `router.push` deixa estado sujo

`router.push("/auth/login/")` faz soft navigation: o page muda mas componentes do layout, cache do react-query e estado do `useForm` continuam vivos. Queries em flight com cookie já apagado podem deixar `isSubmitting=true` num form que voltaremos a renderizar — o botão "Entrar" fica desabilitado silenciosamente e o submit "não faz nada".

## Fix

**Commit 1** (`signin DTO`): adiciona `@IsOptional()` antes do `@IsBoolean()`. `ApiProperty` → `ApiPropertyOptional` pra Swagger semântico.

**Commit 2** (`hard reload no logout`):
\`\`\`diff
- router.push("/auth/login/");
+ window.location.href = "/auth/login";
\`\`\`
Hard reload limpa tudo (cache react-query, estado dos hooks, componentes desmontam de verdade).

## Test plan

- [ ] Login com Lembrar de mim DESMARCADO → entra normalmente
- [ ] Login após logout → entra normalmente, sem reload manual
- [ ] Login → logout → login (3x seguidos) → sempre funciona
- [ ] `curl -X POST /v1/auth/signin` sem `rememberMe` → 401 (credenciais), não 400

## Substitui PR #161

Fechar #161 ao mergear este. Os dois fixes pertencem ao mesmo problema funcional.