### PR TITLE
chore: docker compose pra stack de desenvolvimento (postgres + back + front)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,76 @@
+# Rodando o Sprint Tracker via Docker
+
+Stack de **desenvolvimento** self-contained: Postgres + back NestJS + front Next.js, com hot reload via volumes.
+
+## Pré-requisitos
+
+- Docker Desktop (Mac/Windows) ou Docker Engine (Linux)
+- Portas livres: **3000** (back), **3001** (front), **5433** (Postgres exposto pro host)
+
+> Se você já tem `npm run start:dev` (back) ou `npm run dev` (front) rodando nativamente, pare antes de subir o compose, senão dá colisão de porta.
+
+## Subir tudo
+
+```bash
+docker compose up --build
+```
+
+Primeira vez puxa as imagens, faz `npm install` em cada container e aplica todas as migrations do Prisma. Pode levar de 3 a 8 minutos dependendo da rede. Próximas execuções sobem em segundos.
+
+Em segundo plano (sem prender o terminal):
+
+```bash
+docker compose up -d --build
+docker compose logs -f back front   # ver logs
+```
+
+## Acessar
+
+- **Front:** http://localhost:3001 (Next.js 16)
+- **Back:** http://localhost:3000 (Swagger em `/api/docs`)
+- **Postgres:** `localhost:5433` (user `postgres` / senha `postgres` / db `sprinttacker`)
+
+A porta exposta do Postgres é `5433` (não 5432) pra não colidir com Postgres local que você possa ter. Dentro do compose os containers acessam via service name (`postgres:5432`).
+
+## Hot reload
+
+Volumes bind em `back-end/src`, `back-end/prisma` e `front-end/` inteiro. Mudar código no host = `nest --watch` e Turbopack recompilam dentro do container automaticamente.
+
+## Parar
+
+```bash
+docker compose down            # para os containers, mantém o banco
+docker compose down -v         # para + apaga volumes (banco zerado)
+```
+
+## Operações comuns
+
+```bash
+# Nova migration depois de mexer no schema
+docker compose exec back npx prisma migrate dev --name <descricao>
+
+# Inspecionar dados do banco no Prisma Studio
+docker compose exec back npx prisma studio
+# (abre em http://localhost:5555)
+
+# Resetar o banco do zero (apaga tudo + reaplica migrations)
+docker compose exec back npx prisma migrate reset --force
+
+# Entrar no shell do container
+docker compose exec back sh
+docker compose exec front sh
+
+# Ver só logs de um serviço
+docker compose logs -f back
+```
+
+## Criar primeiro usuário
+
+O banco sobe vazio. Cria conta normal em http://localhost:3001/auth/register ou via psql/Prisma Studio.
+
+## Notas
+
+- `JWT_SECRET` no compose é hardcoded como placeholder de dev. **Não use em prod** — o Dockerfile multi-stage de produção (`back-end/Dockerfile`) lê de env vars do orquestrador.
+- LDAP/Google/Microsoft OAuth estão desligados por padrão. Pra ligar, sobrescreva via `.env` ou edite o compose.
+- Mac: bind mounts usam `:delegated` pra performance melhor (escrita do container fica em cache local antes de sincronizar pro host).
+- iCloud Drive: o `.dockerignore` já filtra os arquivos `* N.ext` que o iCloud cria. Se aparecer build error sobre `backlog.service 2.ts` ou similar, rode o limpa-iCloud da raiz do projeto.

--- a/back-end/.dockerignore
+++ b/back-end/.dockerignore
@@ -1,8 +1,21 @@
 node_modules
+dist
 .git
 *.log
 *.md
 test
 tests
+test-results
+coverage
 .vscode
 .env
+.env.local
+.DS_Store
+# Lixo iCloud (duplicatas que o sync cria como `* N.ext`)
+* [0-9].ts
+* [0-9].tsx
+* [0-9].json
+* [0-9].yml
+* [0-9].yaml
+* [0-9].mjs
+.semgrepignore[ 0-9]*

--- a/back-end/Dockerfile.dev
+++ b/back-end/Dockerfile.dev
@@ -1,0 +1,24 @@
+# Dev container do back-end (NestJS).
+# Hot reload via volume bind do compose. Para PROD use Dockerfile (multi-stage).
+FROM node:22-alpine
+
+# OpenSSL é necessário pelo Prisma client em Alpine.
+RUN apk add --no-cache openssl
+
+WORKDIR /app
+
+# Cacheia npm install separado do código.
+COPY package.json package-lock.json* ./
+RUN npm install
+
+# Copia o resto. O compose vai bind-mountar /app/src e /app/prisma por cima
+# em dev pra refletir mudanças do host instantaneamente.
+COPY . .
+
+# Gera Prisma Client com binários Alpine corretos.
+RUN npx prisma generate
+
+EXPOSE 3000
+
+# `migrate deploy` é idempotente: aplica pendentes, no-op se tudo OK.
+CMD ["sh", "-c", "npx prisma migrate deploy && npm run start:dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,105 @@
+# Sprint Tracker — stack de desenvolvimento self-contained.
+#
+# Uso:
+#   docker compose up --build       (primeira vez ou após mudar deps)
+#   docker compose up               (próximas vezes)
+#   docker compose down             (para tudo)
+#   docker compose down -v          (apaga volumes — perde dados do DB)
+#
+# Após o primeiro `up`, o banco está vazio. Pra criar usuário, use o
+# fluxo normal de registro em http://localhost:3001/auth/register
+# ou crie via prisma studio: `docker compose exec back npx prisma studio`.
+#
+# Hot reload funciona via bind mounts em `src/` e `prisma/` (back) e
+# diretório inteiro do front. Mexer no código do host = rebuild
+# automático dentro do container.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: sprint-tracker-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: sprinttacker
+    ports:
+      - "5433:5432"  # 5433 no host pra não colidir com Postgres local na 5432
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d sprinttacker"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  back:
+    build:
+      context: ./back-end
+      dockerfile: Dockerfile.dev
+    container_name: sprint-tracker-back
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/sprinttacker?schema=public
+      PORT: "3000"
+      NODE_ENV: development
+      BASE_URL: http://localhost:3000
+      BASE_URL_UI: http://localhost:3001
+      BASE_URL_API: http://localhost:3000
+      JWT_SECRET: dev-jwt-secret-change-in-production-please
+      JWT_RESET_SECRET: dev-reset-secret-change-in-production-please
+      ENABLE_GOOGLE_OAUTH: "false"
+      ENABLE_MICROSOFT_OAUTH: "false"
+      ENABLE_LDAP_OAUTH: "false"
+      # LDAP_* placeholder porque o módulo usa getOrThrow no constructor
+      # mesmo com LDAP desabilitado. Valores fake só pra não crashar.
+      LDAP_URL: ldap://disabled
+      LDAP_ADMIN_DN: cn=disabled
+      LDAP_ADMIN_PASSWORD: disabled
+      LDAP_USER_BASE_DN: ou=disabled
+      EMAIL: noreply@dev.local
+      PASS: disabled
+      DEBUG: "false"
+    ports:
+      - "3000:3000"
+    volumes:
+      # Hot reload: bind dos diretórios de código.
+      - ./back-end/src:/app/src:delegated
+      - ./back-end/prisma:/app/prisma:delegated
+      # node_modules como named volume pra não ser sobrescrito pelo bind
+      # do host (binários Mac/Linux são diferentes).
+      - back-node-modules:/app/node_modules
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://localhost:3000/health-check || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
+  front:
+    build:
+      context: ./front-end
+      dockerfile: Dockerfile.dev
+    container_name: sprint-tracker-front
+    depends_on:
+      back:
+        condition: service_healthy
+    environment:
+      NODE_ENV: development
+      # Server-to-server: o Next (rodando no container front) chama o
+      # back pela rede docker via service name.
+      BASE_URL_API: http://back:3000
+      BASE_URL_WS: http://back:3000
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./front-end:/app:delegated
+      - front-node-modules:/app/node_modules
+      - front-next:/app/.next
+
+volumes:
+  postgres-data:
+  back-node-modules:
+  front-next:
+  front-node-modules:

--- a/front-end/.dockerignore
+++ b/front-end/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+.next
 .git
 *.log
 *.md
@@ -6,3 +7,13 @@ test
 tests
 .vscode
 .env
+.env.local
+.DS_Store
+scrap
+# Lixo iCloud (duplicatas que o sync cria como `* N.ext`)
+* [0-9].ts
+* [0-9].tsx
+* [0-9].json
+* [0-9].yml
+* [0-9].yaml
+* [0-9].mjs

--- a/front-end/Dockerfile.dev
+++ b/front-end/Dockerfile.dev
@@ -1,0 +1,14 @@
+# Dev container do front-end (Next.js 16 + Turbopack).
+# Hot reload via volume bind do compose. Para PROD use Dockerfile (multi-stage).
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm install
+
+COPY . .
+
+EXPOSE 3001
+
+CMD ["sh", "-c", "PORT=3001 npm run dev -- --hostname 0.0.0.0"]


### PR DESCRIPTION
## Por quê

Time tava com fricção pra rodar local — passos manuais em 3 terminais, dependência do Postgres do host, configuração de env vars. Com este PR, fica:

\`\`\`bash
docker compose up --build
\`\`\`

E pronto — Postgres + back + front rodando, hot reload funcional, banco com migrations aplicadas.

## O que muda

- **\`back-end/Dockerfile.dev\`** — \`node:22-alpine\`, instala deps, gera Prisma Client com binários Alpine, aplica migrations no start, sobe \`npm run start:dev\` (watch mode).
- **\`front-end/Dockerfile.dev\`** — \`node:22-alpine\`, \`npm run dev\` com \`--hostname 0.0.0.0\` (essencial pro port forwarding do Docker no Mac/Windows).
- **\`docker-compose.yml\`** — 3 serviços encadeados com healthchecks:
  - \`postgres:16-alpine\` (porta exposta 5433 no host pra não colidir com Postgres local)
  - \`back\` (3000) — espera Postgres healthy
  - \`front\` (3001) — espera back healthy
- **\`DOCKER.md\`** — instruções, operações comuns (Prisma Studio, reset DB, shell), troubleshooting iCloud.
- **\`.dockerignore\`** atualizado em ambos pra cobrir \`.next\`, \`scrap/\` e duplicatas iCloud (\`* N.ext\`).

## Hot reload

Volumes bind:
- \`./back-end/src:/app/src:delegated\`
- \`./back-end/prisma:/app/prisma:delegated\`
- \`./front-end:/app:delegated\`

\`node_modules\` em cada container vira **named volume** — sem isso, o bind do host (Mac) sobrescreveria os binários Alpine/Linux do container e tudo quebra.

## Não toca em produção

Os Dockerfile multi-stage existentes (\`back-end/Dockerfile\`, \`front-end/Dockerfile\`) ficam intactos. Eles continuam sendo o caminho pro deploy AWS pelo time DevOps. Este PR adiciona só o **dev**.

## Test plan

- [ ] \`docker compose up --build\` sobe os 3 serviços sem erro (primeira vez leva 3-8 min)
- [ ] http://localhost:3001 carrega tela de login
- [ ] Registro de novo usuário funciona (DB vazio na primeira execução)
- [ ] Login, criar board, criar task funcionam end-to-end
- [ ] Mexer em algum arquivo \`back-end/src/**\` reflete em segundos no container (hot reload)
- [ ] \`docker compose down\` para tudo limpo
- [ ] \`docker compose up\` (sem --build, após o primeiro) sobe em < 30s

## Notas

- \`JWT_SECRET\` é hardcoded como dev placeholder. Comentado em \`DOCKER.md\` que não usa em prod.
- LDAP/OAuth desligados no compose (valores fake só pra não crashar no \`getOrThrow\` do constructor).
- Após o merge, o time pode escolher: continuar rodando nativamente (npm run start:dev em terminais) OU usar o compose. As duas opções ficam disponíveis.