### PR TITLE
fix(csp): afrouxar CSP em dev pro Turbopack + HMR (login não disparava)

### DIFF
--- a/front-end/proxy.ts
+++ b/front-end/proxy.ts
@@ -6,18 +6,37 @@ export function proxy(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
 
   // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
-  const cspHeader = `
-    default-src 'self';
-    script-src 'nonce-${nonce}' 'strict-dynamic' ${isDev ? "'unsafe-eval'" : ''};
-    style-src 'self' https://fonts.googleapis.com ${isDev ? "'unsafe-inline'" : ''};
-    img-src 'self' data:;
-    font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;
-    connect-src 'self';
-    frame-ancestors 'self';
-    form-action 'self';
-    base-uri 'self';
-    object-src 'none';
-  `;
+  //
+  // Em dev (Turbopack/HMR), o Next injeta scripts inline sem nonce e
+  // abre WebSocket pra hot reload. CSP estrito com nonce bloqueia esses
+  // scripts e quebra interações (submit do form de login, por exemplo).
+  // Por isso afrouxamos script-src e connect-src só em dev.
+  // Em prod, mantemos nonce + strict-dynamic + connect-src restrito.
+  const cspHeader = isDev
+    ? `
+      default-src 'self';
+      script-src 'self' 'unsafe-inline' 'unsafe-eval';
+      style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
+      img-src 'self' data: blob:;
+      font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;
+      connect-src 'self' ws: wss: http://localhost:3000 http://back:3000;
+      frame-ancestors 'self';
+      form-action 'self';
+      base-uri 'self';
+      object-src 'none';
+    `
+    : `
+      default-src 'self';
+      script-src 'nonce-${nonce}' 'strict-dynamic';
+      style-src 'self' https://fonts.googleapis.com;
+      img-src 'self' data:;
+      font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;
+      connect-src 'self';
+      frame-ancestors 'self';
+      form-action 'self';
+      base-uri 'self';
+      object-src 'none';
+    `;
   const sanitizedCspHeader = cspHeader.replace(/\s{2,}/g, ' ').trim();
 
   const requestHeaders = new Headers(request.headers);


### PR DESCRIPTION
## Bug

Reportado em demo. Console do browser:

\`\`\`
[Error] Refused to execute a script because it does not appear in
the script-src directive of the Content Security Policy.
\`\`\`

Resultado prático: clicar **Entrar** no form de login não fazia nada — o JS do form não hidratava, então o handler do submit não disparava.

## Causa

\`proxy.ts\` aplicava CSP estrito \`script-src 'nonce-\${nonce}' 'strict-dynamic'\` para **dev E prod**. Em dev, o Next 16/Turbopack injeta scripts inline pra HMR/Fast Refresh **sem** o nonce esperado, e \`connect-src 'self'\` bloqueava o WebSocket do HMR. Em prod isso funcionaria porque o Next injeta nonce nos \`<script>\` SSR gerados — mas o pipeline de dev não.

## Fix

Split do CSP por ambiente:

**Dev** (afrouxado, mas dentro de uma máquina de dev):
\`\`\`
script-src 'self' 'unsafe-inline' 'unsafe-eval';
style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
connect-src 'self' ws: wss: http://localhost:3000 http://back:3000;
img-src 'self' data: blob:;
\`\`\`

**Prod** (estrito, igual antes):
\`\`\`
script-src 'nonce-\${nonce}' 'strict-dynamic';
connect-src 'self';
\`\`\`

\`form-action\`, \`frame-ancestors\`, \`base-uri\` e \`object-src\` continuam estritos em ambos (defesa contra clickjacking/redirect injection vale igual em dev).

## Validação

\`\`\`bash
curl -i http://localhost:3001/auth/login | grep -i content-security
# content-security-policy: default-src 'self'; script-src 'self'
#   'unsafe-inline' 'unsafe-eval'; ...
#   connect-src 'self' ws: wss: http://localhost:3000 http://back:3000;
\`\`\`

## Test plan

- [ ] Hard reload em http://localhost:3001/auth/login
- [ ] Console **sem** o erro "Refused to execute a script..."
- [ ] Clicar **Entrar** → submit dispara e entra no dashboard
- [ ] HMR continua funcionando ao mexer no código
- [ ] Build de produção (\`next build && next start\`) ainda usa CSP estrito (não tem como testar localmente mas o split é por \`process.env.NODE_ENV === 'development'\`)

## Tech debt relacionado

\`app/layout.tsx\` lê \`nonce\` do header mas nunca usa em nenhum \`<Script nonce={...}>\` (SonarCloud já tinha apontado em #160 como "useless assignment to variable 'nonce'"). Em prod, o nonce só funciona se o Next injetar automaticamente nos scripts gerados — vale validar isso quando subir pra AWS.