### PR TITLE
fix: auto-corrigir selectedBoardId stale no BoardSelect (sem precisar do usuário)

### DIFF
--- a/front-end/components/layout/sidebar/board-select.tsx
+++ b/front-end/components/layout/sidebar/board-select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
@@ -15,10 +15,41 @@ export const BoardSelect = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { selectedBoardId, setSelectedBoardId } = useBoardStore();
 
-  const { data } = useQuery({
+  const { data, isSuccess } = useQuery({
     queryKey: ["boards"],
     queryFn: getBoards
   });
+
+  const boards = (data?.success && data.data) ? data.data : [];
+
+  /**
+   * Auto-correção do `selectedBoardId` quando ele aponta pra um board
+   * que não existe mais (banco trocado, board removido, etc.).
+   *
+   * O zustand `useBoardStore` persiste `selectedBoardId` no localStorage
+   * pra "lembrar" o último board entre sessões. Mas se o usuário trocar
+   * de banco (ex: postgres do host → postgres do compose) ou se o board
+   * for excluído por outro usuário, o ID persistido vira lixo — e o
+   * front passa a chamar `/v1/boards/<UUID_VELHO>/...`, recebendo 404
+   * "Board não encontrado" em silêncio.
+   *
+   * Quando a lista carrega:
+   *  - Se o ID atual está na lista, mantém.
+   *  - Se não está e existem boards, seleciona o primeiro.
+   *  - Se não existem boards, limpa.
+   */
+  useEffect(() => {
+    if (!isSuccess) return;
+    const ids = boards.map((b) => b.id);
+    if (selectedBoardId && ids.includes(selectedBoardId)) return;
+    if (boards.length > 0) {
+      setSelectedBoardId(boards[0].id);
+    } else if (selectedBoardId) {
+      // Sem boards e ainda tinha um ID stale persistido → limpa.
+      setSelectedBoardId("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess, boards.length]);
 
   /**
    * Atualiza o store e navega quando a rota depende do boardId na URL.
@@ -40,7 +71,7 @@ export const BoardSelect = () => {
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            {data?.success && data.data?.map((board) => (
+            {boards.map((board) => (
               <SelectItem value={board.id} key={board.id}>{board.name}</SelectItem>
             ))}
           </SelectGroup>


### PR DESCRIPTION
## Bug

Reportado: ao tentar criar uma sprint, aparece toast \`Board não encontrado\` e o usuário fica preso — não tem como saber por que.

## Causa

\`useBoardStore\` (zustand) persiste \`selectedBoardId\` no \`localStorage\` (chave \`board-storage\`) pra "lembrar" o último board entre sessões. Quando o usuário troca de banco (ex: postgres do host → postgres do compose) ou um board é excluído por outro membro, o ID persistido vira lixo:

- Front chama \`/v1/boards/<UUID_VELHO>/sprints\` (etc.)
- Back responde 404 \`Board não encontrado\`
- Toast vermelho sem explicação
- Único jeito de resolver hoje: dev limpar \`localStorage\` ou trocar manualmente no select

Isso é inaceitável — o usuário não pode depender de "abrir DevTools e apagar storage" pra usar o app.

## Fix

\`BoardSelect\` agora valida \`selectedBoardId\` contra a lista real de boards toda vez que o \`useQuery(['boards'])\` completa. Se o ID persistido não existe na lista:

- **Há outros boards** → auto-seleciona o primeiro (transparente, sem prompt)
- **Lista vazia** → limpa o store

\`\`\`tsx
useEffect(() => {
  if (!isSuccess) return;
  const ids = boards.map((b) => b.id);
  if (selectedBoardId && ids.includes(selectedBoardId)) return;
  if (boards.length > 0) setSelectedBoardId(boards[0].id);
  else if (selectedBoardId) setSelectedBoardId("");
}, [isSuccess, boards.length]);
\`\`\`

Próximas chamadas (createSprint, getActiveSprint, qualquer use de \`selectedBoardId\`) usam o ID válido.

## Cenários cobertos

- Troca de banco (host → compose)
- Board excluído por outro usuário enquanto a sessão estava aberta
- \`localStorage\` corrompido por extensão/limpeza parcial
- Primeira sessão em browser sem dados persistidos (já cobria, mas agora é explícito)

## Test plan

- [ ] DevTools → Application → localStorage → setar manualmente \`board-storage\` com UUID inexistente
- [ ] Recarregar a página → BoardSelect mostra o board real (não o lixo)
- [ ] Clicar "Criar sprint" → funciona normal (não dá mais \`Board não encontrado\`)
- [ ] Excluir o único board do usuário → BoardSelect mostra placeholder, sem erro
- [ ] Trocar de banco/ambiente entre sessões → primeiro acesso já pega o board correto