### PR TITLE
feat(sprints): página de histórico com dados reais

### DIFF
--- a/back-end/src/sprint/sprint.controller.ts
+++ b/back-end/src/sprint/sprint.controller.ts
@@ -54,6 +54,20 @@ export class SprintController {
     return this.sprintService.getActive(boardId, user.id);
   }
 
+  @ApiOperation({
+    summary: 'Histórico de sprints encerradas do board',
+    description:
+      'Retorna sprints COMPLETED com tasks separadas em concluídas/incompletas e métricas agregadas',
+  })
+  @ApiResponse({ status: 200, description: 'Histórico retornado' })
+  @Get('boards/:boardId/sprints/history')
+  getHistory(
+    @Param('boardId') boardId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.sprintService.getHistory(boardId, user.id);
+  }
+
   @ApiOperation({ summary: 'Cria uma sprint no board (admin)' })
   @ApiResponse({ status: 201, description: 'Sprint criada' })
   @ApiResponse({ status: 403, description: 'Sem permissão' })

--- a/back-end/src/sprint/sprint.service.ts
+++ b/back-end/src/sprint/sprint.service.ts
@@ -66,6 +66,58 @@ export class SprintService {
     });
   }
 
+  /**
+   * Retorna sprints COMPLETED do board, mais recentes primeiro, com as tasks
+   * agrupadas em concluídas vs. incompletas e métricas agregadas.
+   *
+   * Tasks `ARCHIVED` são excluídas (não contam como concluídas nem incompletas).
+   * Como o schema atual não rastreia movimentação entre sprints, "incompletas"
+   * aqui são tasks que ficaram no sprint fechado sem serem marcadas DONE.
+   */
+  async getHistory(boardId: string, userId: string) {
+    await this.assertBoardAccess(boardId, userId);
+    const sprints = await this.prisma.sprint.findMany({
+      where: { boardId, status: SprintStatus.COMPLETED },
+      orderBy: [{ endDate: 'desc' }],
+      include: {
+        tasks: {
+          where: { deletedAt: null, status: { not: 'ARCHIVED' } },
+          select: {
+            id: true,
+            title: true,
+            status: true,
+            completedAt: true,
+            assignee: {
+              select: { id: true, name: true, userName: true, email: true },
+            },
+            list: { select: { id: true, title: true } },
+          },
+          orderBy: [{ completedAt: 'desc' }, { updatedAt: 'desc' }],
+        },
+      },
+    });
+
+    return sprints.map((sprint) => {
+      const completedTasks = sprint.tasks.filter((t) => t.status === 'DONE');
+      const incompleteTasks = sprint.tasks.filter((t) => t.status !== 'DONE');
+      const total = sprint.tasks.length;
+      const completionRate =
+        total > 0 ? Math.round((completedTasks.length / total) * 100) : 0;
+      const { tasks: _drop, ...rest } = sprint;
+      return {
+        ...rest,
+        completedTasks,
+        incompleteTasks,
+        stats: {
+          total,
+          completed: completedTasks.length,
+          incomplete: incompleteTasks.length,
+          completionRate,
+        },
+      };
+    });
+  }
+
   /** Retorna a sprint ativa (status=ACTIVE) com tasks completas. Null se não houver. */
   async getActive(boardId: string, userId: string) {
     await this.assertBoardAccess(boardId, userId);

--- a/front-end/app/dashboard/sprints/history/page.tsx
+++ b/front-end/app/dashboard/sprints/history/page.tsx
@@ -1,0 +1,9 @@
+import { SprintHistory } from "@/features/sprints/history/sprint-history";
+
+export default function SprintHistoryPage() {
+  return (
+    <div className="w-full p-10">
+      <SprintHistory />
+    </div>
+  );
+}

--- a/front-end/components/layout/sidebar/sidebar.tsx
+++ b/front-end/components/layout/sidebar/sidebar.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { HelpCircle, Logs, Home, Gauge } from "lucide-react";
+import { HelpCircle, Logs, Home, Gauge, History } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BoardSelect } from "./board-select";
 
@@ -11,6 +11,7 @@ const navItems = [
   { label: "Home", href: "/dashboard", icon: Home },
   { label: "Backlog", href: "/dashboard/backlog", icon: Logs },
   { label: "Sprints", href: "/dashboard/sprints", icon: Gauge },
+  { label: "Histórico", href: "/dashboard/sprints/history", icon: History },
 ];
 
 export default function Sidebar() {

--- a/front-end/features/sprints/history/sprint-history.tsx
+++ b/front-end/features/sprints/history/sprint-history.tsx
@@ -1,25 +1,192 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Search,
+  History,
+  FolderOpen,
+  CheckCircle2,
+  Circle,
+  Calendar,
+  Target,
+  User,
+  Gauge,
+} from "lucide-react";
+
 import { Input } from "@/components/ui/input";
-import { Search, History, FolderOpen } from "lucide-react";
-import { SprintCard } from "./sprint-card";
-import { mockSprints as initialMockSprints } from "@/lib/mocks/tasks";
-import { useTaskStore } from "@/stores/use-task-store";
-import { Task } from "@/types/task";
+import { useBoardStore } from "@/stores/use-board-store";
+import {
+  getSprintHistory,
+  type HistorySprint,
+  type HistorySprintTask,
+} from "@/lib/actions/sprint";
+
+function formatDate(d: string) {
+  try {
+    return new Date(d).toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "2-digit",
+    });
+  } catch {
+    return d;
+  }
+}
+
+function assigneeLabel(a: HistorySprintTask["assignee"]) {
+  if (!a) return "Sem responsável";
+  return a.name || a.userName || a.email || "—";
+}
+
+function TaskRow({
+  task,
+  done,
+}: {
+  task: HistorySprintTask;
+  done: boolean;
+}) {
+  const Icon = done ? CheckCircle2 : Circle;
+  return (
+    <li className="flex items-center gap-3 py-2 px-3 rounded-md hover:bg-muted/40">
+      <Icon
+        size={16}
+        className={
+          done
+            ? "text-emerald-600 dark:text-emerald-400 shrink-0"
+            : "text-muted-foreground shrink-0"
+        }
+      />
+      <span
+        className={`flex-1 text-sm ${done ? "line-through text-muted-foreground" : ""}`}
+      >
+        {task.title}
+      </span>
+      <span className="text-xs text-muted-foreground hidden md:flex items-center gap-1">
+        <User size={12} />
+        {assigneeLabel(task.assignee)}
+      </span>
+    </li>
+  );
+}
+
+function SprintHistoryCard({ sprint }: { sprint: HistorySprint }) {
+  const { stats, completedTasks, incompleteTasks } = sprint;
+  return (
+    <article className="rounded-lg border bg-card">
+      <header className="p-5 border-b">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div>
+            <h2 className="text-lg font-semibold">{sprint.name}</h2>
+            {sprint.goal && (
+              <p className="text-sm text-muted-foreground mt-1 flex items-center gap-2">
+                <Target size={14} />
+                {sprint.goal}
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground mt-2 flex items-center gap-2">
+              <Calendar size={12} />
+              {formatDate(sprint.startDate)} → {formatDate(sprint.endDate)}
+            </p>
+          </div>
+          <div className="text-right">
+            <div className="text-2xl font-bold tabular-nums">
+              {stats.completionRate}%
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {stats.completed} de {stats.total} concluídas
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 h-1.5 w-full rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full bg-emerald-500 transition-all"
+            style={{ width: `${stats.completionRate}%` }}
+          />
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x">
+        <section className="p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-400 mb-2">
+            Concluídas ({completedTasks.length})
+          </h3>
+          {completedTasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground px-3 py-2">
+              Nenhuma task concluída neste sprint.
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {completedTasks.map((t) => (
+                <TaskRow key={t.id} task={t} done />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="p-4">
+          <h3 className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-2">
+            Não concluídas ({incompleteTasks.length})
+          </h3>
+          {incompleteTasks.length === 0 ? (
+            <p className="text-sm text-muted-foreground px-3 py-2">
+              Tudo foi entregue neste sprint. 🎉
+            </p>
+          ) : (
+            <ul className="space-y-1">
+              {incompleteTasks.map((t) => (
+                <TaskRow key={t.id} task={t} done={false} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </article>
+  );
+}
 
 export function SprintHistory() {
+  const { selectedBoardId } = useBoardStore();
   const [search, setSearch] = useState("");
-  const sprints = useTaskStore((state) => state.sprints);
 
-  const filteredSprints = sprints
-    .map((sprint) => ({
-      ...sprint,
-      items: sprint.items.filter((task: Task) =>
-        task.title.toLowerCase().includes(search.toLowerCase())
-      ),
-    }))
-    .filter((sprint) => sprint.items.length > 0);
+  const { data, isLoading } = useQuery({
+    queryKey: ["sprint-history", selectedBoardId],
+    queryFn: () => getSprintHistory(selectedBoardId!),
+    enabled: !!selectedBoardId,
+    staleTime: 30_000,
+  });
+
+  const sprints: HistorySprint[] = data?.success ? data.data : [];
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return sprints;
+    return sprints
+      .map((s) => ({
+        ...s,
+        completedTasks: s.completedTasks.filter((t) =>
+          t.title.toLowerCase().includes(q),
+        ),
+        incompleteTasks: s.incompleteTasks.filter((t) =>
+          t.title.toLowerCase().includes(q),
+        ),
+      }))
+      .filter(
+        (s) => s.completedTasks.length > 0 || s.incompleteTasks.length > 0,
+      );
+  }, [sprints, search]);
+
+  if (!selectedBoardId) {
+    return (
+      <div className="max-w-md mx-auto mt-16 flex flex-col items-center text-center bg-muted/20 border border-dashed border-border rounded-lg p-10">
+        <Gauge size={26} className="text-muted-foreground mb-3" />
+        <h1 className="text-xl font-semibold">Escolha um board</h1>
+        <p className="text-sm text-muted-foreground mt-2">
+          Sprints são organizadas por board. Selecione um na sidebar primeiro.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full space-y-8">
@@ -27,7 +194,9 @@ export function SprintHistory() {
         <h1 className="text-3xl font-bold tracking-tight">
           Histórico de Sprints
         </h1>
-        <p className="text-muted-foreground mt-1 text-sm">Veja todas as sprints já feitas</p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Sprints encerradas — o que foi concluído e o que ficou pendente.
+        </p>
       </div>
 
       <div className="relative flex items-center w-80 bg-muted rounded-lg">
@@ -41,31 +210,38 @@ export function SprintHistory() {
       </div>
 
       <div className="space-y-6">
-        {sprints.length === 0 && (
+        {isLoading && (
+          <div className="space-y-4">
+            {[0, 1].map((i) => (
+              <div key={i} className="h-48 rounded-lg bg-muted animate-pulse" />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && sprints.length === 0 && (
           <div className="flex flex-col items-center justify-center py-20 text-center bg-muted/20 border border-dashed rounded-lg">
             <History className="h-10 w-10 text-muted-foreground mb-4" />
-            <h3 className="text-lg font-medium">Nenhuma sprint encontrada</h3>
+            <h3 className="text-lg font-medium">Nenhum sprint encerrado</h3>
             <p className="text-sm text-muted-foreground max-w-sm mt-1">
-              O histórico está vazio. Comece a planejar e concluir sprints para vê-las aqui.
+              Quando você encerrar uma sprint, ela aparece aqui com o que foi
+              concluído e o que ficou pendente.
             </p>
           </div>
         )}
 
-        {sprints.length > 0 && filteredSprints.length === 0 && (
+        {!isLoading && sprints.length > 0 && filtered.length === 0 && (
           <div className="flex flex-col items-center justify-center py-20 text-center bg-muted/20 border border-dashed rounded-lg">
             <FolderOpen className="h-10 w-10 text-muted-foreground mb-4" />
             <h3 className="text-lg font-medium">Nenhum resultado</h3>
             <p className="text-sm text-muted-foreground max-w-sm mt-1">
-              Não encontramos nenhuma tarefa correspondente a "{search}". Tente buscar por outro termo.
+              Não encontramos tarefa com &quot;{search}&quot;. Tente outro
+              termo.
             </p>
           </div>
         )}
 
-        {filteredSprints.map((sprint) => (
-          <SprintCard
-            key={sprint.id}
-            sprint={sprint}
-          />
+        {filtered.map((s) => (
+          <SprintHistoryCard key={s.id} sprint={s} />
         ))}
       </div>
     </div>

--- a/front-end/lib/actions/sprint.ts
+++ b/front-end/lib/actions/sprint.ts
@@ -41,6 +41,31 @@ export interface ActiveSprint extends Sprint {
   tasks: SprintTask[];
 }
 
+export interface HistorySprintTask {
+  id: string;
+  title: string;
+  status: "TODO" | "IN_PROGRESS" | "BLOCKED" | "DONE" | "ARCHIVED";
+  completedAt: string | null;
+  assignee: {
+    id: string;
+    name: string | null;
+    userName: string | null;
+    email: string | null;
+  } | null;
+  list: { id: string; title: string };
+}
+
+export interface HistorySprint extends Sprint {
+  completedTasks: HistorySprintTask[];
+  incompleteTasks: HistorySprintTask[];
+  stats: {
+    total: number;
+    completed: number;
+    incomplete: number;
+    completionRate: number;
+  };
+}
+
 export async function listSprints(boardId: string) {
   try {
     const safeBoardId = validateId(boardId, "boardId");
@@ -68,6 +93,21 @@ export async function getActiveSprint(boardId: string) {
     return {
       success: false as const,
       error: handleAxiosError(error, "Erro ao buscar sprint ativa"),
+    };
+  }
+}
+
+export async function getSprintHistory(boardId: string) {
+  try {
+    const safeBoardId = validateId(boardId, "boardId");
+    const response = await api.get(
+      `/v1/boards/${safeBoardId}/sprints/history`,
+    );
+    return { success: true as const, data: response.data as HistorySprint[] };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Erro ao buscar histórico de sprints"),
     };
   }
 }


### PR DESCRIPTION
## Resumo

Substitui o componente `SprintHistory` (que estava usando mock) por uma página real conectada ao backend:

- **Backend**: novo `GET /v1/boards/:boardId/sprints/history` retorna sprints `COMPLETED` com tasks já separadas em `completedTasks` / `incompleteTasks` + agregados (`total`, `completed`, `incomplete`, `completionRate`)
- **Front**: nova rota `/dashboard/sprints/history` com card por sprint mostrando goal, datas, barra de progresso e duas colunas (verde / âmbar)
- **Sidebar**: link "Histórico" adicionado abaixo de "Sprints"

## Limitação conhecida

Como o schema atual não rastreia movimentação de task entre sprints (`Task.sprintId` é estado atual, sem log), "incompletas" aqui são tasks que ficaram no sprint fechado sem terem sido marcadas DONE. Não dá pra responder "essa task vinha da sprint anterior" ainda.

Isso é exatamente o escopo do **PR 2** (futuro): definir comportamento ao encerrar sprint (preferência do produto: modal pergunta o que fazer com tasks incompletas) + estender `TaskLog` com `TASK_SPRINT_CHANGED` capturando `{fromSprintId, toSprintId}`.

## Test plan

- [ ] Login com user existente
- [ ] Clicar "Histórico" na sidebar → carrega `/dashboard/sprints/history`
- [ ] Ver sprint "dasda" (única COMPLETED no DB de dev) listado
- [ ] Estado vazio: criar e excluir todas sprints COMPLETED → ver mensagem "Nenhum sprint encerrado"
- [ ] Sem board selecionado: deve mostrar empty state "Escolha um board"
- [ ] Busca: digitar título de task existente → filtra sprints; texto inexistente → "Nenhum resultado"

🤖 Generated with [Claude Code](https://claude.com/claude-code)