### PR TITLE
fix(board): deletar TaskLog antes de Task no remove (FK violation)

### DIFF
--- a/back-end/src/board/board.service.ts
+++ b/back-end/src/board/board.service.ts
@@ -156,6 +156,9 @@ export class BoardService {
         const taskIds = tasks.map((t) => t.id);
 
         if (taskIds.length) {
+          // TaskLog.task FK não tem onDelete cascade, então precisa ser limpo
+          // antes das tasks. TaskComment.task tem Cascade, sem cleanup manual.
+          await tx.taskLog.deleteMany({ where: { taskId: { in: taskIds } } });
           await tx.taskLabel.deleteMany({ where: { taskId: { in: taskIds } } });
           await tx.task.deleteMany({ where: { id: { in: taskIds } } });
         }
@@ -163,6 +166,7 @@ export class BoardService {
         await tx.list.deleteMany({ where: { id: { in: listIds } } });
       }
 
+      // Logs órfãos do board (sem task associada) também são removidos.
       await tx.taskLog.deleteMany({ where: { boardId } });
 
       // Tasks já foram deletadas acima; sprints podem ser removidas direto


### PR DESCRIPTION
## Bug

`DELETE /v1/boards/:id` retornava **500 Internal Server Error** quando o board tinha tasks com logs:

\`\`\`
PrismaClientKnownRequestError: Foreign key constraint violated on
the constraint: \`TaskLog_taskId_fkey\`
  code: 'P2003'
\`\`\`

## Causa

A transação em [board.service.ts:142-188](back-end/src/board/board.service.ts) apagava na ordem:

1. \`TaskLabel\` (por taskId)
2. \`Task\` ❌ **viola FK** — \`TaskLog.taskId\` ainda referencia essas tasks
3. \`TaskLog\` (por boardId) — nunca chega

\`TaskLog.task\` não tem \`onDelete: Cascade\` no schema, então tasks referenciadas por logs não podem ser deletadas.

## Fix

Adicionado \`tx.taskLog.deleteMany({ where: { taskId: { in: taskIds } } })\` antes do \`task.deleteMany\`. Mantida a limpeza por \`boardId\` depois pra cobrir logs órfãos (sem task associada — não deveria existir, mas defensivo).

\`TaskComment\` não precisa de cleanup manual: tem \`onDelete: Cascade\` no schema.

## Test plan

- [ ] Login
- [ ] Tentar excluir o board "Sprint-Tracker" (que tem tasks com logs) → antes 500, agora 200
- [ ] Confirmar no DB: \`SELECT count(*) FROM "TaskLog";\` zera para esse board após delete
- [ ] Excluir board sem tasks → continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)