### PR TITLE
feat(sidebar): adicionar link Board apontando pro board selecionado

### DIFF
--- a/front-end/components/layout/sidebar/sidebar.tsx
+++ b/front-end/components/layout/sidebar/sidebar.tsx
@@ -3,19 +3,66 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { HelpCircle, Logs, Home, Gauge, History } from "lucide-react";
+import {
+  HelpCircle,
+  Logs,
+  Home,
+  Gauge,
+  History,
+  KanbanSquare,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BoardSelect } from "./board-select";
-
-const navItems = [
-  { label: "Home", href: "/dashboard", icon: Home },
-  { label: "Backlog", href: "/dashboard/backlog", icon: Logs },
-  { label: "Sprints", href: "/dashboard/sprints", icon: Gauge },
-  { label: "Histórico", href: "/dashboard/sprints/history", icon: History },
-];
+import { useBoardStore } from "@/stores/use-board-store";
 
 export default function Sidebar() {
   const pathname = usePathname();
+  const { selectedBoardId } = useBoardStore();
+
+  const boardHref = selectedBoardId
+    ? `/dashboard/board/${selectedBoardId}`
+    : "#";
+  const boardDisabled = !selectedBoardId;
+  const boardActive = pathname.startsWith("/dashboard/board/");
+
+  const navItems = [
+    {
+      label: "Home",
+      href: "/dashboard",
+      icon: Home,
+      isActive: pathname === "/dashboard",
+      disabled: false,
+    },
+    {
+      label: "Board",
+      href: boardHref,
+      icon: KanbanSquare,
+      isActive: boardActive,
+      disabled: boardDisabled,
+      disabledTitle: "Selecione um board no dropdown acima primeiro",
+    },
+    {
+      label: "Backlog",
+      href: "/dashboard/backlog",
+      icon: Logs,
+      isActive: pathname === "/dashboard/backlog",
+      disabled: false,
+    },
+    {
+      label: "Sprints",
+      href: "/dashboard/sprints",
+      icon: Gauge,
+      isActive: pathname === "/dashboard/sprints",
+      disabled: false,
+    },
+    {
+      label: "Histórico",
+      href: "/dashboard/sprints/history",
+      icon: History,
+      isActive: pathname === "/dashboard/sprints/history",
+      disabled: false,
+    },
+  ];
 
   return (
     <aside className="hidden md:flex flex-col gap-8 min-w-64 h-auto bg-muted/50 border-r-border border px-4 py-6">
@@ -32,15 +79,35 @@ export default function Sidebar() {
         <BoardSelect />
       </div>
       <nav className="flex flex-col gap-2">
-        {navItems.map(({ label, href, icon: Icon }) => {
-          const isActive = pathname === href;
+        {navItems.map(({ label, href, icon: Icon, isActive, disabled, disabledTitle }) => {
+          const baseClass =
+            "px-6 py-3 flex items-center gap-3 rounded-lg font-semibold";
+          const enabledClass =
+            "text-muted-foreground! hover:bg-red-100 dark:hover:bg-red-950/40 hover:text-red-700! dark:hover:text-red-400!";
+          const activeClass =
+            "bg-red-100 dark:bg-red-950/40 text-red-700! dark:text-red-400!";
+          const disabledClass =
+            "text-muted-foreground/40 cursor-not-allowed select-none";
+
+          if (disabled) {
+            return (
+              <span
+                key={label}
+                title={disabledTitle}
+                aria-disabled="true"
+                className={cn(baseClass, disabledClass)}
+              >
+                <Icon size={24} strokeWidth={2} />
+                <span>{label}</span>
+              </span>
+            );
+          }
+
           return (
             <Link
-              key={href}
+              key={label}
               href={href}
-              className={cn("px-6 py-3 flex items-center gap-3 rounded-lg text-muted-foreground! hover:bg-red-100 dark:hover:bg-red-950/40 hover:text-red-700! dark:hover:text-red-400! font-semibold",
-                isActive ? "bg-red-100 dark:bg-red-950/40 text-red-700! dark:text-red-400!" : ""
-              )}
+              className={cn(baseClass, enabledClass, isActive && activeClass)}
             >
               <Icon size={24} strokeWidth={2} />
               <span>{label}</span>
@@ -54,7 +121,10 @@ export default function Sidebar() {
           <Plus size={20} strokeWidth={2.5} />
           Criar Tarefa
         </button> */}
-        <Link href="#" className="flex px-4 py-3 items-center text-muted-foreground! font-semibold gap-3">
+        <Link
+          href="#"
+          className="flex px-4 py-3 items-center text-muted-foreground! font-semibold gap-3"
+        >
           <HelpCircle size={20} strokeWidth={1.8} />
           <span>Suporte</span>
         </Link>


### PR DESCRIPTION
## Resumo

Adiciona item "Board" na sidebar entre **Home** e **Backlog**. Aponta pro \`/dashboard/board/[selectedBoardId]\` usando o mesmo store que alimenta o dropdown do topo.

## Por que

Antes, pra ir do kanban do board pra qualquer outra página e voltar, o usuário tinha que:
1. Clicar em Home
2. Achar o card do board no grid
3. Clicar nele

Agora é 1 clique.

## Comportamento

- **Com board selecionado**: link normal, active state quando \`pathname.startsWith("/dashboard/board/")\`
- **Sem board selecionado**: vira \`<span>\` desabilitado (\`cursor-not-allowed\`, opacity reduzida, title explicativo). Não redireciona pra lugar nenhum quebrado.

Ícone: \`KanbanSquare\` do Lucide — semanticamente representa o kanban do board.

## Test plan

- [x] Com board "X" selecionado no dropdown → clicar "Board" → vai pra \`/dashboard/board/X\`
- [x] Sem board selecionado → item aparece dimmed, cursor "não", tooltip explica que precisa selecionar
- [x] Trocar de board no dropdown enquanto está em outra página → clicar "Board" → vai pro board novo
- [x] Estar em \`/dashboard/board/X\` → item "Board" aparece destacado (active state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)