### PR TITLE
feat(poker): botão Estimar com Poker + modal de criar sessão

### DIFF
--- a/front-end/app/dashboard/board/[id]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/page.tsx
@@ -41,6 +41,7 @@ import { EditBoardDialog } from "@/features/board/edit-board-dialog";
 import { LabelsDialog } from "@/features/board/labels-dialog";
 import { MembersDialog } from "@/features/board/members-dialog";
 import { TaskCard } from "@/features/board/task-card";
+import { CreatePokerSessionModal } from "@/features/board/create-poker-session-modal";
 
 import type { Task } from "../../../../types/task";
 
@@ -83,6 +84,8 @@ export default function BoardPage() {
   const [editBoardOpen, setEditBoardOpen] = useState(false);
   const [membersOpen, setMembersOpen] = useState(false);
   const [labelsOpen, setLabelsOpen] = useState(false);
+  const [pokerModalOpen, setPokerModalOpen] = useState(false);
+  const [pokerInitialTaskId, setPokerInitialTaskId] = useState<string | undefined>();
   const [optimisticLists, setOptimisticLists] = useState<ListWithTasks[] | null>(null);
   const [search, setSearch] = useState("");
   const [assigneeFilter, setAssigneeFilter] = useState<string>("__all__");
@@ -169,6 +172,12 @@ export default function BoardPage() {
         </button>
       </div>
     );
+  }
+
+  function handleStartPoker() {
+    setPokerInitialTaskId(editingTask?.id);
+    setEditingTask(null);
+    setPokerModalOpen(true);
   }
 
   async function handleDeleteList(id: string, title: string) {
@@ -622,7 +631,16 @@ export default function BoardPage() {
         canAssign={isAdmin}
         canDelete={canEditTasks}
         canViewHistory={isAdmin}
+        canPoker={isAdmin}
+        onStartPoker={handleStartPoker}
         currentUserId={myUserId}
+      />
+
+      <CreatePokerSessionModal
+        boardId={boardId}
+        isOpen={pokerModalOpen}
+        onClose={() => setPokerModalOpen(false)}
+        initialTaskId={pokerInitialTaskId}
       />
 
       <MembersDialog

--- a/front-end/app/dashboard/board/[id]/poker/[sessionId]/page.tsx
+++ b/front-end/app/dashboard/board/[id]/poker/[sessionId]/page.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Copy,
+  Check,
+  Dices,
+  ClipboardList,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { getBoardById } from "@/lib/actions/board";
+import { getPokerSession } from "@/lib/actions/poker";
+import { validateId } from "@/lib/utils/validateId";
+
+export default function PokerSessionPage() {
+  const params = useParams();
+  const router = useRouter();
+  const [copied, setCopied] = useState(false);
+
+  let boardId: string;
+  let sessionId: string;
+
+  try {
+    boardId = validateId(params.id, "boardId");
+    sessionId = validateId(params.sessionId, "sessionId");
+  } catch {
+    return (
+      <div className="p-8 max-w-2xl mx-auto flex flex-col items-center justify-center py-24 text-center">
+        <p className="text-foreground font-medium text-lg">Sessão inválida</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          O link desta sessão não é válido.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PokerSessionView boardId={boardId} sessionId={sessionId} router={router} copied={copied} setCopied={setCopied} />
+  );
+}
+
+function PokerSessionView({
+  boardId,
+  sessionId,
+  router,
+  copied,
+  setCopied,
+}: {
+  boardId: string;
+  sessionId: string;
+  router: ReturnType<typeof useRouter>;
+  copied: boolean;
+  setCopied: (v: boolean) => void;
+}) {
+  const { data: boardData, isLoading: loadingBoard } = useQuery({
+    queryKey: ["board", boardId],
+    queryFn: () => getBoardById(boardId),
+    enabled: !!boardId,
+  });
+
+  const { data: sessionData, isLoading: loadingSession } = useQuery({
+    queryKey: ["poker-session", boardId, sessionId],
+    queryFn: () => getPokerSession(boardId, sessionId),
+    enabled: !!boardId && !!sessionId,
+  });
+
+  const board = boardData?.success ? boardData.data : null;
+  const session = sessionData?.success ? sessionData.data : null;
+
+  async function copyLink() {
+    const url = window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const input = document.createElement("input");
+      input.value = url;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand("copy");
+      document.body.removeChild(input);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const isLoading = loadingBoard || loadingSession;
+
+  if (isLoading) {
+    return (
+      <div className="p-8 max-w-3xl mx-auto space-y-6">
+        <div className="h-6 w-24 bg-muted rounded animate-pulse" />
+        <div className="h-32 bg-muted rounded-xl animate-pulse" />
+        <div className="h-48 bg-muted rounded-xl animate-pulse" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 lg:p-8 max-w-3xl mx-auto space-y-6">
+      <button
+        onClick={() => router.push(`/dashboard/board/${boardId}`)}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-red-600 dark:hover:text-red-400 transition-colors"
+      >
+        <ArrowLeft size={16} />
+        Voltar para o board
+      </button>
+
+      {/* Header */}
+      <div className="rounded-xl bg-card shadow-sm border border-border p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-xl bg-violet-100 dark:bg-violet-950/40 flex items-center justify-center shrink-0">
+              <Dices size={20} className="text-violet-600 dark:text-violet-400" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold text-foreground">
+                Poker Planning
+              </h1>
+              {board?.name && (
+                <p className="text-sm text-muted-foreground mt-0.5">
+                  {board.name}
+                </p>
+              )}
+            </div>
+          </div>
+          <span className="text-[11px] font-mono text-muted-foreground bg-muted px-2 py-1 rounded hidden sm:inline-block">
+            #{sessionId.slice(0, 8)}
+          </span>
+        </div>
+      </div>
+
+      {/* Share link */}
+      <div className="rounded-xl bg-card shadow-sm border border-border p-5">
+        <h2 className="text-sm font-semibold text-foreground mb-3">
+          Compartilhar sessão
+        </h2>
+        <p className="text-xs text-muted-foreground mb-3">
+          Qualquer membro do board pode participar desta sessão usando o link
+          abaixo.
+        </p>
+        <div className="flex gap-2">
+          <div className="flex-1 bg-muted rounded-lg px-3 py-2 text-sm text-muted-foreground font-mono truncate border border-border">
+            {typeof window !== "undefined" ? window.location.href : ""}
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={copyLink}
+            className={
+              copied
+                ? "gap-2 border-emerald-400 text-emerald-600 dark:text-emerald-400 shrink-0"
+                : "gap-2 shrink-0"
+            }
+          >
+            {copied ? (
+              <>
+                <Check size={15} />
+                Copiado!
+              </>
+            ) : (
+              <>
+                <Copy size={15} />
+                Copiar link
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* Task list */}
+      <div className="rounded-xl bg-card shadow-sm border border-border p-5">
+        <h2 className="text-sm font-semibold text-foreground mb-4 flex items-center gap-2">
+          <ClipboardList size={15} />
+          Tasks a estimar
+          {session && (
+            <span className="text-xs font-normal text-muted-foreground">
+              ({session.taskIds.length})
+            </span>
+          )}
+        </h2>
+
+        {!session ? (
+          <div className="py-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              Não foi possível carregar as tasks da sessão. Verifique se o
+              backend está ativo.
+            </p>
+          </div>
+        ) : session.taskIds.length === 0 ? (
+          <p className="text-sm text-muted-foreground italic py-4 text-center">
+            Nenhuma task nesta sessão.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {session.taskIds.map((taskId, index) => (
+              <li
+                key={taskId}
+                className="flex items-center gap-3 p-3 rounded-lg border border-border bg-muted/20"
+              >
+                <span className="w-6 h-6 rounded-full bg-violet-100 dark:bg-violet-950/40 text-violet-700 dark:text-violet-400 flex items-center justify-center text-xs font-semibold shrink-0">
+                  {index + 1}
+                </span>
+                <span className="text-xs font-mono text-muted-foreground truncate flex-1">
+                  {taskId}
+                </span>
+                <span className="text-[10px] px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 font-medium shrink-0">
+                  Aguardando
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front-end/features/board/create-poker-session-modal.tsx
+++ b/front-end/features/board/create-poker-session-modal.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Dices, Search } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { getActiveSprint, type SprintTask } from "@/lib/actions/sprint";
+import { createPokerSession } from "@/lib/actions/poker";
+
+interface CreatePokerSessionModalProps {
+  boardId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  initialTaskId?: string;
+}
+
+export function CreatePokerSessionModal({
+  boardId,
+  isOpen,
+  onClose,
+  initialTaskId,
+}: CreatePokerSessionModalProps) {
+  const router = useRouter();
+  const [search, setSearch] = useState("");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() =>
+    initialTaskId ? new Set([initialTaskId]) : new Set(),
+  );
+  const [loading, setLoading] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["sprint-active", boardId],
+    queryFn: () => getActiveSprint(boardId),
+    enabled: isOpen && !!boardId,
+    staleTime: 15_000,
+  });
+
+  const sprintTasks: SprintTask[] = useMemo(() => {
+    if (!data?.success || !data.data) return [];
+    return data.data.tasks;
+  }, [data]);
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return sprintTasks;
+    return sprintTasks.filter(
+      (t) =>
+        t.title.toLowerCase().includes(term) ||
+        t.description?.toLowerCase().includes(term),
+    );
+  }, [sprintTasks, search]);
+
+  function toggleTask(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    if (selectedIds.size === filtered.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(filtered.map((t) => t.id)));
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (selectedIds.size === 0) return;
+    setLoading(true);
+    const result = await createPokerSession(boardId, Array.from(selectedIds));
+    setLoading(false);
+
+    if (!result.success) {
+      toast.error(result.error || "Erro ao criar sessão");
+      return;
+    }
+
+    onClose();
+    router.push(`/dashboard/board/${boardId}/poker/${result.data.id}`);
+  }
+
+  const allSelected =
+    filtered.length > 0 && filtered.every((t) => selectedIds.has(t.id));
+  const hasNoSprint = !isLoading && data?.success && !data.data;
+  const hasTasks = sprintTasks.length > 0;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <DialogContent className="w-[95vw] max-w-lg max-h-[90vh] overflow-y-auto p-4 sm:p-6">
+        <DialogHeader>
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 rounded-lg bg-violet-100 dark:bg-violet-950/40 flex items-center justify-center">
+              <Dices size={16} className="text-violet-600 dark:text-violet-400" />
+            </div>
+            <DialogTitle>Poker Planning</DialogTitle>
+          </div>
+          <DialogDescription>
+            Selecione as tasks da sprint ativa que serão estimadas na sessão.
+          </DialogDescription>
+        </DialogHeader>
+
+        {hasNoSprint ? (
+          <div className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              Nenhuma sprint ativa. Adicione tasks a uma sprint antes de iniciar
+              uma sessão de Poker Planning.
+            </p>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4 mt-2">
+            {hasTasks && (
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+                <Input
+                  placeholder="Buscar tasks..."
+                  className="pl-9"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                />
+              </div>
+            )}
+
+            <div className="space-y-1.5 max-h-72 overflow-y-auto pr-1">
+              {isLoading ? (
+                <div className="py-8 text-center text-xs text-muted-foreground">
+                  Carregando tasks da sprint...
+                </div>
+              ) : filtered.length === 0 ? (
+                <div className="py-8 text-center text-xs text-muted-foreground italic">
+                  {hasTasks
+                    ? "Nenhuma task casa com a busca"
+                    : "A sprint ativa não possui tasks. Adicione tasks à sprint primeiro."}
+                </div>
+              ) : (
+                <>
+                  {filtered.length > 1 && (
+                    <label className="flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer hover:bg-muted/40 transition-colors border-b border-border mb-1">
+                      <Checkbox
+                        checked={allSelected}
+                        onCheckedChange={toggleAll}
+                        className="data-[state=checked]:bg-violet-600 data-[state=checked]:border-violet-600"
+                      />
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Selecionar todas ({filtered.length})
+                      </span>
+                    </label>
+                  )}
+                  {filtered.map((task) => (
+                    <label
+                      key={task.id}
+                      className="flex items-start gap-3 px-3 py-2.5 rounded-lg border border-border cursor-pointer hover:bg-muted/30 transition-colors has-checked:border-violet-400 has-checked:bg-violet-50 dark:has-checked:bg-violet-950/20"
+                    >
+                      <Checkbox
+                        checked={selectedIds.has(task.id)}
+                        onCheckedChange={() => toggleTask(task.id)}
+                        className="mt-0.5 shrink-0 data-[state=checked]:bg-violet-600 data-[state=checked]:border-violet-600"
+                      />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-foreground truncate">
+                          {task.title}
+                        </p>
+                        {task.description && (
+                          <p className="text-xs text-muted-foreground line-clamp-1 mt-0.5">
+                            {task.description}
+                          </p>
+                        )}
+                        <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                          {task.list?.title}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </>
+              )}
+            </div>
+
+            {selectedIds.size > 0 && (
+              <p className="text-xs text-muted-foreground">
+                {selectedIds.size}{" "}
+                {selectedIds.size === 1 ? "task selecionada" : "tasks selecionadas"}
+              </p>
+            )}
+
+            <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-2">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+                className="w-full sm:w-auto"
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                disabled={loading || selectedIds.size === 0}
+                className="bg-violet-600 hover:bg-violet-700 text-white w-full sm:w-auto gap-2"
+              >
+                <Dices size={15} />
+                {loading ? "Criando sessão..." : "Iniciar sessão"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front-end/features/board/edit-task-dialog.tsx
+++ b/front-end/features/board/edit-task-dialog.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { CalendarIcon, Trash2 } from "lucide-react";
+import { CalendarIcon, Trash2, Dices } from "lucide-react";
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
@@ -37,6 +37,8 @@ interface EditTaskDialogProps {
   canAssign?: boolean;
   canDelete?: boolean;
   canViewHistory?: boolean;
+  canPoker?: boolean;
+  onStartPoker?: () => void;
   currentUserId?: string;
 }
 
@@ -51,6 +53,8 @@ export function EditTaskDialog({
   canAssign = false,
   canDelete = false,
   canViewHistory = false,
+  canPoker = false,
+  onStartPoker,
   currentUserId,
 }: EditTaskDialogProps) {
   const queryClient = useQueryClient();
@@ -214,6 +218,20 @@ export function EditTaskDialog({
           <TaskComments taskId={task.id} currentUserId={currentUserId} />
 
           <TaskHistory taskId={task.id} enabled={canViewHistory} />
+
+          {canPoker && (
+            <div className="pt-1">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onStartPoker}
+                className="w-full gap-2 border-violet-200 text-violet-700 hover:bg-violet-50 hover:border-violet-400 dark:border-violet-800 dark:text-violet-400 dark:hover:bg-violet-950/20"
+              >
+                <Dices size={15} />
+                Estimar com Poker Planning
+              </Button>
+            </div>
+          )}
 
           <div className="flex flex-col-reverse sm:flex-row justify-between gap-2 pt-2">
             {canDelete ? (

--- a/front-end/lib/actions/poker.ts
+++ b/front-end/lib/actions/poker.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import api from "@/lib/api/axios";
+import { handleAxiosError } from "@/lib/utils/handle-axios-error";
+import { validateId } from "@/lib/utils/validateId";
+
+export interface PokerSession {
+  id: string;
+  boardId: string;
+  taskIds: string[];
+  createdAt: string;
+}
+
+export async function createPokerSession(boardId: string, taskIds: string[]) {
+  try {
+    const safeBoardId = validateId(boardId, "boardId");
+    const safeTaskIds = taskIds.map((id, i) => validateId(id, `taskId[${i}]`));
+    const response = await api.post(
+      `/v1/boards/${safeBoardId}/poker-sessions`,
+      { taskIds: safeTaskIds },
+    );
+    const data = response.data as PokerSession;
+    const safeSessionId = validateId(data.id, "sessionId");
+    return { success: true as const, data: { ...data, id: safeSessionId } };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Erro ao criar sessão de Poker Planning"),
+    };
+  }
+}
+
+export async function getPokerSession(boardId: string, sessionId: string) {
+  try {
+    const safeBoardId = validateId(boardId, "boardId");
+    const safeSessionId = validateId(sessionId, "sessionId");
+    const response = await api.get(
+      `/v1/boards/${safeBoardId}/poker-sessions/${safeSessionId}`,
+    );
+    return { success: true as const, data: response.data as PokerSession };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: handleAxiosError(error, "Erro ao carregar sessão de Poker Planning"),
+    };
+  }
+}


### PR DESCRIPTION
- Adiciona botão 'Estimar com Poker Planning' no EditTaskDialog, visível apenas para OWNER/ADMIN (prop canPoker)
- Cria CreatePokerSessionModal com seleção de tasks da sprint ativa via checkboxes
- Redireciona para /dashboard/board/[id]/poker/[sessionId] após criar sessão
- Adiciona server actions createPokerSession e getPokerSession com validateId em todos os IDs (boardId, taskIds, sessionId) para mitigar SSRF
- Cria página da sessão com botão de copiar link compartilhável