### PR TITLE
chore: gitignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ scrap/
 * [0-9].css
 * [0-9].md
 .semgrepignore[ 0-9]*
+
+# Override local: aponta o back pro RDS da AWS (contém secret) — não commitar
+docker-compose.override.yml


### PR DESCRIPTION
Ignora o `docker-compose.override.yml` (override local usado pra apontar o back pro RDS da AWS em testes — contém secret). Evita commit acidental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)