### PR TITLE
fix(front): corrige classname inválida do calendar que quebrava o bui…

### DIFF
--- a/front-end/components/ui/calendar.tsx
+++ b/front-end/components/ui/calendar.tsx
@@ -87,7 +87,7 @@ function Calendar({
             : "flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground",
           defaultClassNames.caption_label
         ),
-        table: "w-full border-collapse",
+        month_grid: "w-full border-collapse",
         weekdays: cn("flex", defaultClassNames.weekdays),
         weekday: cn(
           "flex-1 rounded-(--cell-radius) text-[0.8rem] font-normal text-muted-foreground select-none",


### PR DESCRIPTION
…ld de produção

O `calendar.tsx` (do PR #178) usava a key `table` no objeto classNames do react-day-picker, mas no v10 essa key se chama `month_grid`. O `next dev` (Turbopack) não checa o tipo estrito, então passou batido — mas o `next build` de produção falha:

  Type error: 'table' does not exist in type 'Partial<ClassNames>'

Esse foi o erro que derrubou o build do front no CI/CD (EKS), travando o deploy na versão antiga. Fix: `table` -> `month_grid`.