### PR TITLE
fix(back): não exigir LDAP_USER_BASE_DN no boot (destrava deploy do back)

### DIFF
--- a/back-end/src/auth/auth.service.ts
+++ b/back-end/src/auth/auth.service.ts
@@ -46,8 +46,12 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly emailService: EmailService,
   ) {
+    // LDAP é opcional. Usar get() com default em vez de getOrThrow() pra
+    // não derrubar o boot quando LDAP está desligado e as vars LDAP_* não
+    // estão setadas. `userBaseDn` só é consumido nos métodos de login LDAP,
+    // que exigem ENABLE_LDAP_OAUTH e validam a config no momento do uso.
     this.userBaseDn =
-      this.configService.getOrThrow<string>('LDAP_USER_BASE_DN');
+      this.configService.get<string>('LDAP_USER_BASE_DN') ?? '';
   }
 
   // Gera um token JWT com base no payload fornecido.


### PR DESCRIPTION
## Problema

O front já deployou (✅, depois do fix do ECR), mas o **back não** — o job é path-filtered (`back-end/**`) e nada de back mudou, então fica `skipped`. Resultado: **front novo + back #154 antigo** = features de sprint (histórico, encerrar, filtro backlog) dão erro.

Além disso, o back tinha o bloqueio latente: `AuthService` faz `getOrThrow('LDAP_USER_BASE_DN')` no **constructor** (boot), e o manifest de prod não tem `LDAP_*` → CrashLoopBackOff.

## Fix

Troca `getOrThrow` por `get(...) ?? ''` pra `LDAP_USER_BASE_DN`. A var só é usada nos métodos de login LDAP (que exigem ENABLE_LDAP_OAUTH). Resultado:
1. Back **não crasha** no boot sem `LDAP_*` (não precisa mais de placeholder no manifest).
2. É um change em `back-end/**` → **dispara o build+deploy do back** no CI/CD.

## ⚠️ Dependência restante (DevOps)

Pro back subir saudável, o Secret **`sprint-tracker-secrets`** precisa ter `DATABASE_URL`, `JWT_SECRET`, `JWT_RESET_SECRET` populados (os valores que passei por canal seguro). Sem o DATABASE_URL, o back crasha por falta de conexão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)