### PR TITLE
fix(front): basePath /sprint em produção (corrige 404 no deploy)

### DIFF
--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -5,6 +5,11 @@ const isDev = process.env.NODE_ENV !== 'production';
 const nextConfig: NextConfig = {
   output: 'standalone',
   poweredByHeader: false,
+  // Em produção o app é servido sob https://bayarea.dataiesb.com/sprint.
+  // basePath faz o Next prefixar todas as URLs internas (links, redirects,
+  // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
+  // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
+  basePath: isDev ? undefined : '/sprint',
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `


### PR DESCRIPTION
## Bug

`https://bayarea.dataiesb.com/sprint` e qualquer navegação dão **404** ("Página não encontrada" do app). A API (`/sprint/api/*`) funciona.

## Causa raiz

O app é servido sob `/sprint`, mas o `next.config` **não tem `basePath`**. Sem ele, o Next gera URLs internas sem o prefixo:
- `/sprint` → redirect de auth → `/auth/login` (sem /sprint) → cai no root → 404
- assets, links, redirects, todos sem `/sprint`

## Fix

`basePath: isDev ? undefined : '/sprint'` — prefixa tudo em produção, mantém dev local em `localhost:3001/` (sem prefixo, via NODE_ENV). Não precisa de mudança no CI/CD.

## ⚠️ Requisito de ingress (DevOps confirmar ANTES de mergear)

O `basePath` assume que o **ingress passa `/sprint/*` pro front sem remover o prefixo** (setup padrão de sub-path do Next). 

- Se o ingress **passa direto** (não strip) → este fix resolve ✅
- Se o ingress **remove o `/sprint`** antes de mandar pro front → o basePath quebra (app espera o prefixo, recebe sem). Nesse caso: configurar o ingress pra **não** remover o prefixo (ou usar subdomínio `sprint.bayarea...` com o app no root, sem basePath).

Como o merge dispara deploy automático, **confirmar o comportamento do ingress antes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)