### PR TITLE
fix(front): redirects basePath-aware (corrige tela preta no /sprint)

### DIFF
--- a/front-end/app/page.tsx
+++ b/front-end/app/page.tsx
@@ -1,5 +1,9 @@
+import { redirect } from "next/navigation";
+
+// A raiz (/ em dev, /sprint em prod) não tem página própria — redireciona
+// pro dashboard. redirect() do next/navigation respeita o basePath, então
+// em prod vai pra /sprint/dashboard. O middleware (proxy.ts) cuida da auth
+// dali (manda pro login se não houver sessão).
 export default function Home() {
-  return (
-    <></>
-  );
+  redirect("/dashboard");
 }

--- a/front-end/proxy.ts
+++ b/front-end/proxy.ts
@@ -42,11 +42,15 @@ export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
 
+  // nextUrl.clone() preserva o basePath (/sprint em prod). Setar .pathname
+  // e redirecionar mantém o prefixo — diferente de new URL(path, request.url),
+  // que gera caminho absoluto SEM basePath e quebra no deploy em sub-path.
   const isProtectedRoute = !request.nextUrl.pathname.startsWith('/auth');
   if (isProtectedRoute) {
     const tokenCookie = request.cookies.get('sprinttacker-session');
     if (!tokenCookie?.value) {
-      const loginURL = new URL('/auth/login', request.url);
+      const loginURL = request.nextUrl.clone();
+      loginURL.pathname = '/auth/login';
       const redirectResponse = NextResponse.redirect(loginURL);
       redirectResponse.headers.set('Content-Security-Policy', sanitizedCspHeader);
       return redirectResponse;
@@ -55,7 +59,8 @@ export function proxy(request: NextRequest) {
 
   const homeToDashboard = request.nextUrl.pathname === '/';
   if (homeToDashboard) {
-    const dashboardURL = new URL('/dashboard', request.url);
+    const dashboardURL = request.nextUrl.clone();
+    dashboardURL.pathname = '/dashboard';
     const redirectResponse = NextResponse.redirect(dashboardURL);
     redirectResponse.headers.set('Content-Security-Policy', sanitizedCspHeader);
     return redirectResponse;


### PR DESCRIPTION
## Bug

Depois do basePath (#186), `/sprint` virou **tela preta** (página vazia, console limpo). Causa: dois redirects não eram basePath-aware.

## Fixes

1. **`proxy.ts` (middleware):** `new URL('/auth/login', request.url)` gera caminho absoluto **sem** o basePath → redirect ia pra `/auth/login` (sem `/sprint`) → 404. Trocado por `request.nextUrl.clone()` + `.pathname`, que preserva o basePath.
2. **`app/page.tsx`:** retornava `<></>`. A raiz do basePath não bate no matcher do middleware, então `/sprint` renderizava a página vazia (tela preta). Agora `redirect('/dashboard')` (respeita basePath).

## Verificação

Dev local inalterado (sem basePath, redireciona como antes). Em prod: `/sprint` → `/sprint/dashboard` → (middleware) → `/sprint/auth/login`.

⚠️ Continua dependendo do ingress passar `/sprint/*` sem strip (já confirmado funcionando pelo #186 — assets e páginas carregam sob /sprint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)