### PR TITLE
fix(front): corrige logos quebrados sob basePath (images.unoptimized)

### DIFF
--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
   // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
   // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
   basePath: isDev ? undefined : '/sprint',
+  // Otimizador de imagem do Next (/_next/image) retorna 400 sob basePath
+  // no deploy standalone — ele tenta buscar a imagem em /images (sem o
+  // /sprint) e falha. unoptimized faz o <Image> servir o arquivo cru em
+  // /sprint/images/... (que existe), corrigindo os logos quebrados.
+  // São assets estáticos pequenos, otimização não faz diferença aqui.
+  images: { unoptimized: true },
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `


### PR DESCRIPTION
## Bug

Os logos do IESB aparecem quebrados (ícone de imagem quebrada) no login e na sidebar do deploy.

## Causa

Diagnóstico ao vivo:
- `/sprint/images/iesb-logo.png` → **200** (a imagem existe e carrega)
- `/sprint/_next/image?url=%2Fimages%2Fiesb-logo.png&w=256&q=75` → **400** (o otimizador do next/image falha)

O otimizador, sob basePath no standalone, tenta buscar a imagem em `/images` (sem `/sprint`) internamente e dá 400.

## Fix

`images: { unoptimized: true }` no `next.config` — o `<Image>` passa a servir o arquivo cru em `/sprint/images/...` (que dá 200). São logos estáticos pequenos; otimização não faz diferença. Corrige login, register, forgot-password e sidebar de uma vez. Sem CSS com `url(/images)` (já chequei), então isso cobre tudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)