### PR TITLE
fix(front): custom image loader pro basePath (corrige logos de vez)

### DIFF
--- a/front-end/image-loader.ts
+++ b/front-end/image-loader.ts
@@ -1,0 +1,15 @@
+// Custom loader pro next/image respeitar o basePath em produção.
+//
+// Problema: <Image src="/images/x.png"> com string não prefixa o basePath
+// sozinho. O otimizador (/_next/image) dá 400 sob basePath no standalone,
+// e com unoptimized o src vira /images/... (sem /sprint) → 404.
+//
+// Este loader prefixa o /sprint em produção (igual ao basePath do
+// next.config) e devolve a imagem crua. URLs absolutas (ex: avatares
+// externos) passam sem alteração.
+const basePath = process.env.NODE_ENV === "production" ? "/sprint" : "";
+
+export default function imageLoader({ src }: { src: string }): string {
+  if (/^https?:\/\//.test(src)) return src;
+  return `${basePath}${src}`;
+}

--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -10,12 +10,13 @@ const nextConfig: NextConfig = {
   // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
   // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
   basePath: isDev ? undefined : '/sprint',
-  // Otimizador de imagem do Next (/_next/image) retorna 400 sob basePath
-  // no deploy standalone — ele tenta buscar a imagem em /images (sem o
-  // /sprint) e falha. unoptimized faz o <Image> servir o arquivo cru em
-  // /sprint/images/... (que existe), corrigindo os logos quebrados.
-  // São assets estáticos pequenos, otimização não faz diferença aqui.
-  images: { unoptimized: true },
+  // Custom loader (image-loader.ts) prefixa o basePath /sprint no src das
+  // imagens em produção. Sem isso o <Image> renderiza /images/... sem o
+  // /sprint → 404 (o otimizador padrão também dava 400 sob basePath).
+  images: {
+    loader: "custom",
+    loaderFile: "./image-loader.ts",
+  },
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `


### PR DESCRIPTION
## Contexto

Sequência dos logos quebrados sob basePath:
1. `<Image>` otimizado → `/sprint/_next/image?url=/images/x.png` → **400** (otimizador falha sob basePath)
2. `#189` colocou `unoptimized` → `<Image>` virou `src="/images/x.png"` → **404** (sem o /sprint)

Causa de fundo: `next/image` **não prefixa o basePath** no `src` string.

## Fix

Custom loader (`image-loader.ts`) que prefixa `/sprint` em produção:
```ts
const basePath = process.env.NODE_ENV === "production" ? "/sprint" : "";
export default function imageLoader({ src }) {
  if (/^https?:\/\//.test(src)) return src; // URLs absolutas: não mexe
  return `${basePath}${src}`;
}
```
`<Image src="/images/x.png">` → loader → `/sprint/images/x.png` → **200**. Corrige todos os `<Image>` de uma vez (login, register, forgot-password, sidebar), sem mexer nos componentes. Dev local inalterado (basePath vazio → src original).

⚠️ Substitui o `unoptimized` do #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)