### PR TITLE
fix(front): logout redireciona pro /sprint/auth/login (basePath)

### DIFF
--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { useQuery } from "@tanstack/react-query";
 import { removeCookie } from "@/lib/utils/session-cookie";
+import { withBasePath } from "@/lib/base-path";
 import { getUserProfile } from "@/lib/actions/profile";
 import styles from "./style.module.css";
 import { useSprintStore } from "@/stores/use-sprint-store";
@@ -47,7 +48,7 @@ export default function Header() {
     // react-query e desmonta todos os componentes/forms do dashboard. Sem
     // isso, queries em flight com cookie já apagado podem deixar estado
     // sujo e travar o próximo submit de login.
-    window.location.href = "/auth/login";
+    window.location.href = withBasePath("/auth/login");
   };
 
   return (

--- a/front-end/hooks/auth/use-login.ts
+++ b/front-end/hooks/auth/use-login.ts
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { login } from "@/lib/actions/auth";
+import { withBasePath } from "@/lib/base-path";
 import { LoginFormData, loginSchema } from "../../app/auth/login/login-schema";
 
 export function useLogin() {
@@ -45,7 +46,7 @@ export function useLogin() {
   };
 
   const handleOAuth = (provider: string) => {
-    window.location.href = `/api/v1/auth/${provider}`;
+    window.location.href = withBasePath(`/api/v1/auth/${provider}`);
   };
 
   return {

--- a/front-end/lib/base-path.ts
+++ b/front-end/lib/base-path.ts
@@ -1,0 +1,14 @@
+/**
+ * basePath do app. Vazio em dev (localhost:3001/), "/sprint" em produção
+ * (servido em bayarea.dataiesb.com/sprint — ver basePath no next.config).
+ *
+ * O Next prefixa o basePath sozinho em <Link>, router.push e redirect() do
+ * next/navigation. Mas APIs do browser (window.location) NÃO conhecem o
+ * basePath — então redirects via window.location precisam usar withBasePath().
+ */
+export const BASE_PATH =
+  process.env.NODE_ENV === "production" ? "/sprint" : "";
+
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}


### PR DESCRIPTION
## Bug (reportado)

Ao deslogar, o app manda pra `bayarea.dataiesb.com/auth/login` (sem `/sprint`) → 404. O endpoint certo é `/sprint/auth/login`.

## Causa

`header/index.tsx` faz `window.location.href = "/auth/login"`. `window.location` é API do browser e **não** conhece o basePath do Next, então o `/sprint` não é adicionado.

## Fix

Helper `withBasePath()` (`lib/base-path.ts`) que prefixa `/sprint` em produção (vazio em dev). Aplicado em:
- `header/index.tsx` — logout → `withBasePath("/auth/login")`
- `use-login.ts` — handleOAuth → `withBasePath(...)` (OAuth está off, mas fica correto)

Redirects do Next (`<Link>`, `router.push`, `redirect()`) já respeitam o basePath sozinhos — só os via `window.location` precisavam do helper. Os `window.location.href` da página de poker apenas **leem** a URL atual (não redirecionam), então não foram tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)