### PR TITLE
Fase 3 multi-board — frontend (puxar de vários boards + selo de origem)

### DIFF
--- a/front-end/app/dashboard/sprints/page.tsx
+++ b/front-end/app/dashboard/sprints/page.tsx
@@ -447,9 +447,14 @@ function SprintTaskCard({
           {task.description}
         </p>
       )}
-      <div className="flex items-center justify-between mt-2 text-[11px]">
-        <span className="text-muted-foreground/80 truncate">
-          {task.list?.title}
+      <div className="flex items-center justify-between mt-2 text-[11px] gap-2">
+        <span className="text-muted-foreground/80 truncate flex items-center gap-1.5 min-w-0">
+          {task.list?.board?.title && (
+            <span className="shrink-0 px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
+              {task.list.board.title}
+            </span>
+          )}
+          <span className="truncate">{task.list?.title}</span>
         </span>
         {initial ? (
           <div className="flex items-center gap-1">

--- a/front-end/features/sprints/add-task-dialog.tsx
+++ b/front-end/features/sprints/add-task-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Search, Plus } from "lucide-react";
@@ -14,11 +14,20 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { getAllList } from "@/lib/actions/list";
+import { getBoards } from "@/lib/actions/board";
 import { addTaskToSprint } from "@/lib/actions/sprint";
 import type { Task } from "@/types/task";
 
 interface AddTaskDialogProps {
+  /** Board padrão (o selecionado na sidebar). O usuário pode trocar. */
   boardId: string;
   sprintId: string;
   isOpen: boolean;
@@ -34,11 +43,26 @@ export function AddTaskDialog({
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
   const [adding, setAdding] = useState<string | null>(null);
+  // Board que está sendo navegado (multi-board: dá pra puxar de vários).
+  const [browseBoardId, setBrowseBoardId] = useState(boardId);
+
+  useEffect(() => {
+    if (boardId) setBrowseBoardId(boardId);
+  }, [boardId]);
+
+  const { data: boardsData } = useQuery({
+    queryKey: ["boards"],
+    queryFn: getBoards,
+    enabled: isOpen,
+    staleTime: 30_000,
+  });
+  const boards =
+    boardsData?.success && boardsData.data ? boardsData.data : [];
 
   const { data, isLoading } = useQuery({
-    queryKey: ["board-lists", boardId],
-    queryFn: () => getAllList(boardId),
-    enabled: isOpen && !!boardId,
+    queryKey: ["board-lists", browseBoardId],
+    queryFn: () => getAllList(browseBoardId),
+    enabled: isOpen && !!browseBoardId,
   });
 
   const candidates = useMemo<Task[]>(() => {
@@ -63,8 +87,11 @@ export function AddTaskDialog({
     const r = await addTaskToSprint(sprintId, task.id);
     setAdding(null);
     if (r.success) {
-      queryClient.invalidateQueries({ queryKey: ["sprint-active", boardId] });
-      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      // sprint-active é por-dono agora; invalida todas as variações
+      queryClient.invalidateQueries({ queryKey: ["sprint-active"] });
+      queryClient.invalidateQueries({
+        queryKey: ["board-lists", browseBoardId],
+      });
       toast.success(`"${task.title}" adicionada à sprint`);
     } else {
       toast.error(r.error || "Erro ao adicionar");
@@ -77,11 +104,26 @@ export function AddTaskDialog({
         <DialogHeader>
           <DialogTitle>Adicionar task à sprint</DialogTitle>
           <DialogDescription>
-            Selecione uma task do board que ainda não está em sprint.
+            Escolha um board e adicione tasks que ainda não estão em sprint.
+            Você pode puxar de vários boards.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 mt-2">
+          {/* Seletor de board (multi-board) */}
+          <Select value={browseBoardId} onValueChange={setBrowseBoardId}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Escolha o board" />
+            </SelectTrigger>
+            <SelectContent>
+              {boards.map((b) => (
+                <SelectItem key={b.id} value={b.id}>
+                  {b.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
@@ -100,7 +142,7 @@ export function AddTaskDialog({
             ) : filtered.length === 0 ? (
               <div className="text-xs text-muted-foreground italic py-6 text-center">
                 {candidates.length === 0
-                  ? "Sem tasks elegíveis (todas já estão em uma sprint ou arquivadas)"
+                  ? "Sem tasks elegíveis neste board (todas já estão em uma sprint ou arquivadas)"
                   : "Nenhuma task casa com a busca"}
               </div>
             ) : (

--- a/front-end/features/sprints/history/sprint-history.tsx
+++ b/front-end/features/sprints/history/sprint-history.tsx
@@ -62,6 +62,11 @@ function TaskRow({
       >
         {task.title}
       </span>
+      {task.list?.board?.title && (
+        <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium hidden sm:inline">
+          {task.list.board.title}
+        </span>
+      )}
       <span className="text-xs text-muted-foreground hidden md:flex items-center gap-1">
         <User size={12} />
         {assigneeLabel(task.assignee)}

--- a/front-end/lib/actions/sprint.ts
+++ b/front-end/lib/actions/sprint.ts
@@ -34,6 +34,8 @@ export interface SprintTask extends Task {
   list: {
     id: string;
     title: string;
+    // board de origem (multi-board) — incluído pelo getActive
+    board?: { id: string; title: string };
   };
 }
 
@@ -52,7 +54,8 @@ export interface HistorySprintTask {
     userName: string | null;
     email: string | null;
   } | null;
-  list: { id: string; title: string };
+  // board de origem (multi-board) — incluído pelo getHistory
+  list: { id: string; title: string; board?: { id: string; title: string } };
 }
 
 export interface HistorySprint extends Sprint {


### PR DESCRIPTION
## Fase 3 do multi-board sprint (frontend)

Stacked sobre #192 (que já contém Fase 1 + Fase 2, pois #193 foi mergeado nela). Adiciona **1 commit**.

### O que muda pro usuário
- **Adicionar task de qualquer board:** o diálogo "Adicionar task à sprint" ganhou um **seletor de board**. Antes só listava tasks do board selecionado na sidebar; agora puxa de **qualquer board que você é dono**. O board do sidebar entra como padrão, mas você troca à vontade.
- **Selo de origem:** cada card da sprint ativa e cada linha do histórico mostram um **selo com o board de onde a task veio** — essencial agora que uma sprint mistura tasks de vários boards.

### Arquivos
- `features/sprints/add-task-dialog.tsx` — seletor de board + busca de listas do board navegado; invalidação ampla de `sprint-active`.
- `app/dashboard/sprints/page.tsx` — selo de board no `SprintTaskCard`.
- `features/sprints/history/sprint-history.tsx` — selo de board no `TaskRow` do histórico.
- `lib/actions/sprint.ts` — tipos `SprintTask.list.board` e `HistorySprintTask.list.board` (já populados pelo `getActive`/`getHistory` da Fase 2).

### Validação
- `tsc --noEmit` limpo (0 erros).

### Fica para depois (follow-up, opcional)
- **UI de mapeamento coluna→status** para opt-in da automação em colunas com nome fora do padrão. Colunas com nome padrão (Backlog, Em andamento, Concluído, etc.) **já foram mapeadas automaticamente** pela migration da Fase 1 — a automação status↔coluna já funciona pra elas.
- Remoção (cosmética) do gate "Escolha um board" na página de sprint — hoje a sprint do dono já aparece com qualquer board selecionado (backend é owner-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)