### PR TITLE
fix(sec): hardening securityContext dos Deployments k8s (Semgrep)

### DIFF
--- a/back-end/prisma/migrations/20260605200720_sprint_multiboard_and_list_status/migration.sql
+++ b/back-end/prisma/migrations/20260605200720_sprint_multiboard_and_list_status/migration.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- Fase 1 (multi-board): Sprint.ownerId + List.status
+--
+-- Aditiva e segura. A sprint passa a gravar o dono (ownerId), mas
+-- continua nascendo sob um board (boardId non-null) por ora.
+-- boardId nullable + cross-board + permissões por-owner = Fase 2.
+-- ============================================================
+
+-- ---------- Sprint: grava o dono ----------
+
+-- ownerId: adiciona nullable, popula do board, torna obrigatório
+ALTER TABLE "Sprint" ADD COLUMN "ownerId" TEXT;
+UPDATE "Sprint" s SET "ownerId" = b."ownerId"
+  FROM "Board" b WHERE s."boardId" = b."id";
+ALTER TABLE "Sprint" ALTER COLUMN "ownerId" SET NOT NULL;
+
+-- FK do owner
+ALTER TABLE "Sprint" ADD CONSTRAINT "Sprint_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Índices novos
+CREATE INDEX "Sprint_ownerId_idx" ON "Sprint"("ownerId");
+CREATE INDEX "Sprint_ownerId_status_idx" ON "Sprint"("ownerId", "status");
+
+-- ---------- List: status mapeado (automação status<->coluna) ----------
+
+ALTER TABLE "List" ADD COLUMN "status" "Status";
+
+-- Heurística: mapeia o título da coluna pro status. lower()+LIKE cobre
+-- acentos porque o radical buscado não tem acento (conclu, andamento...).
+-- Aplicado em ordem; cada UPDATE só toca listas ainda sem status.
+UPDATE "List" SET "status" = 'DONE' WHERE "status" IS NULL AND (
+  lower("title") LIKE '%conclu%' OR lower("title") LIKE '%done%' OR
+  lower("title") LIKE '%finaliz%' OR lower("title") LIKE '%pronto%'
+);
+UPDATE "List" SET "status" = 'BLOCKED' WHERE "status" IS NULL AND (
+  lower("title") LIKE '%impedid%' OR lower("title") LIKE '%bloque%' OR
+  lower("title") LIKE '%blocked%'
+);
+UPDATE "List" SET "status" = 'IN_PROGRESS' WHERE "status" IS NULL AND (
+  lower("title") LIKE '%andamento%' OR lower("title") LIKE '%progress%' OR
+  lower("title") LIKE '%fazendo%' OR lower("title") LIKE '%doing%'
+);
+UPDATE "List" SET "status" = 'TODO' WHERE "status" IS NULL AND (
+  lower("title") LIKE '%fazer%' OR lower("title") LIKE '%todo%' OR
+  lower("title") LIKE '%to-do%' OR lower("title") LIKE '%backlog%' OR
+  lower("title") LIKE '%novo%' OR lower("title") LIKE '%aberto%' OR
+  lower("title") LIKE '%pendente%' OR lower("title") LIKE '%open%'
+);
+
+-- Dedupe: garante 1 lista por (board, status). Extras voltam pra NULL
+-- (coluna livre), pra não violar o unique abaixo.
+UPDATE "List" SET "status" = NULL
+WHERE "id" IN (
+  SELECT "id" FROM (
+    SELECT "id", ROW_NUMBER() OVER (
+      PARTITION BY "boardId", "status" ORDER BY "position" ASC, "createdAt" ASC
+    ) AS rn
+    FROM "List" WHERE "status" IS NOT NULL
+  ) ranked WHERE rn > 1
+);
+
+-- Unique (boardId, status). No Postgres NULLs são distintos, então várias
+-- colunas livres (status NULL) por board continuam permitidas.
+CREATE UNIQUE INDEX "List_boardId_status_key" ON "List"("boardId", "status");

--- a/back-end/prisma/migrations/20260605204234_sprint_boardid_nullable_owner_active/migration.sql
+++ b/back-end/prisma/migrations/20260605204234_sprint_boardid_nullable_owner_active/migration.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- Fase 2 (multi-board): Sprint boardId nullable + 1 ativa por dono
+--
+-- A sprint deixa de ser presa a 1 board: boardId vira opcional e o
+-- vínculo é com o dono (ownerId, da Fase 1). Pode conter tasks de
+-- vários boards do dono (regra aplicada no addTask do service).
+-- ============================================================
+
+-- boardId vira opcional
+ALTER TABLE "Sprint" ALTER COLUMN "boardId" DROP NOT NULL;
+
+-- FK do board: ON DELETE CASCADE -> SET NULL
+-- (deletar 1 board não apaga mais a sprint; ela só perde o board de origem)
+ALTER TABLE "Sprint" DROP CONSTRAINT "Sprint_boardId_fkey";
+ALTER TABLE "Sprint" ADD CONSTRAINT "Sprint_boardId_fkey"
+  FOREIGN KEY ("boardId") REFERENCES "Board"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Regra "1 sprint ACTIVE por dono": antes era 1 por board, então um dono
+-- com sprints ativas em boards diferentes teria várias. Mantém a mais
+-- recente ACTIVE e rebaixa as outras pra PLANNED.
+UPDATE "Sprint" SET "status" = 'PLANNED'
+WHERE "id" IN (
+  SELECT "id" FROM (
+    SELECT "id", ROW_NUMBER() OVER (
+      PARTITION BY "ownerId" ORDER BY "startDate" DESC, "createdAt" DESC
+    ) AS rn
+    FROM "Sprint" WHERE "status" = 'ACTIVE'
+  ) ranked WHERE rn > 1
+);

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -57,14 +57,14 @@ model Board {
 model Sprint {
   id        String       @id @default(uuid())
   ownerId   String
-  boardId   String
+  boardId   String?
   name      String
   goal      String?
   startDate DateTime
   endDate   DateTime
   status    SprintStatus @default(PLANNED)
   owner     User         @relation("OwnerSprints", fields: [ownerId], references: [id])
-  board     Board        @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  board     Board?       @relation(fields: [boardId], references: [id], onDelete: SetNull)
   tasks     Task[]
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -31,6 +31,7 @@ model User {
   taskComments        TaskComment[]  @relation("TaskCommentUser")
   notifications       Notification[]
   sentInvites         Invite[]       @relation("Sender")
+  ownedSprints        Sprint[]       @relation("OwnerSprints")
 
   @@unique([authProvider, providerId], name: "AuthProviderAndIdUnique")
 }
@@ -55,17 +56,21 @@ model Board {
 
 model Sprint {
   id        String       @id @default(uuid())
+  ownerId   String
   boardId   String
   name      String
   goal      String?
   startDate DateTime
   endDate   DateTime
   status    SprintStatus @default(PLANNED)
+  owner     User         @relation("OwnerSprints", fields: [ownerId], references: [id])
   board     Board        @relation(fields: [boardId], references: [id], onDelete: Cascade)
   tasks     Task[]
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
 
+  @@index([ownerId])
+  @@index([ownerId, status])
   @@index([boardId])
   @@index([status])
 }
@@ -97,12 +102,15 @@ model List {
   id         String   @id @default(uuid())
   boardId    String
   title      String
+  status     Status?
   position   Int
   isArchived Boolean  @default(false)
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
   board      Board    @relation(fields: [boardId], references: [id])
   tasks      Task[]
+
+  @@unique([boardId, status])
 }
 
 model Task {

--- a/back-end/src/sprint/sprint.service.ts
+++ b/back-end/src/sprint/sprint.service.ts
@@ -32,34 +32,27 @@ export class SprintService {
     }
   }
 
-  /** Garante que o usuário tem acesso ao board (qualquer membro). */
-  private async assertBoardAccess(boardId: string, userId: string) {
-    const board = await this.prisma.board.findUnique({
-      where: { id: boardId },
-      include: { members: { where: { userId } } },
-    });
-    if (!board) throw new NotFoundException('Board não encontrado');
-    const isOwner = board.ownerId === userId;
-    const isMember = board.members.length > 0;
-    if (!isOwner && !isMember) {
-      throw new ForbiddenException('Você não tem acesso a este board');
-    }
-  }
-
-  /** Acha a sprint, valida acesso e retorna sprint + boardId. */
-  private async assertSprintAccess(sprintId: string, userId: string) {
+  /**
+   * Acha a sprint e garante que o usuário é o DONO dela.
+   * Com multi-board a sprint é do usuário (ownerId), não de um board —
+   * então a permissão de gerenciar é por dono, não por admin de board.
+   */
+  private async assertSprintOwner(sprintId: string, userId: string) {
     const sprint = await this.prisma.sprint.findUnique({
       where: { id: sprintId },
     });
     if (!sprint) throw new NotFoundException('Sprint não encontrada');
-    await this.assertBoardAccess(sprint.boardId, userId);
+    if (sprint.ownerId !== userId) {
+      throw new ForbiddenException('Apenas o dono pode gerenciar esta sprint');
+    }
     return sprint;
   }
 
-  async listByBoard(boardId: string, userId: string) {
-    await this.assertBoardAccess(boardId, userId);
+  // Lista as sprints do USUÁRIO (multi-board). boardId no path é ignorado —
+  // mantido por compat com a rota /boards/:boardId/sprints.
+  async listByBoard(_boardId: string, userId: string) {
     return this.prisma.sprint.findMany({
-      where: { boardId },
+      where: { ownerId: userId },
       orderBy: [{ startDate: 'desc' }],
       include: {
         _count: { select: { tasks: true } },
@@ -75,10 +68,9 @@ export class SprintService {
    * Como o schema atual não rastreia movimentação entre sprints, "incompletas"
    * aqui são tasks que ficaram no sprint fechado sem serem marcadas DONE.
    */
-  async getHistory(boardId: string, userId: string) {
-    await this.assertBoardAccess(boardId, userId);
+  async getHistory(_boardId: string, userId: string) {
     const sprints = await this.prisma.sprint.findMany({
-      where: { boardId, status: SprintStatus.COMPLETED },
+      where: { ownerId: userId, status: SprintStatus.COMPLETED },
       orderBy: [{ endDate: 'desc' }],
       include: {
         tasks: {
@@ -91,7 +83,14 @@ export class SprintService {
             assignee: {
               select: { id: true, name: true, userName: true, email: true },
             },
-            list: { select: { id: true, title: true } },
+            // board de origem de cada task (multi-board)
+            list: {
+              select: {
+                id: true,
+                title: true,
+                board: { select: { id: true, title: true } },
+              },
+            },
           },
           orderBy: [{ completedAt: 'desc' }, { updatedAt: 'desc' }],
         },
@@ -119,11 +118,13 @@ export class SprintService {
     });
   }
 
-  /** Retorna a sprint ativa (status=ACTIVE) com tasks completas. Null se não houver. */
-  async getActive(boardId: string, userId: string) {
-    await this.assertBoardAccess(boardId, userId);
+  /**
+   * Retorna a sprint ativa do USUÁRIO (1 por dono). boardId no path é
+   * ignorado — a sprint é multi-board. Null se não houver.
+   */
+  async getActive(_boardId: string, userId: string) {
     const sprint = await this.prisma.sprint.findFirst({
-      where: { boardId, status: SprintStatus.ACTIVE },
+      where: { ownerId: userId, status: SprintStatus.ACTIVE },
       include: {
         tasks: {
           where: { deletedAt: null },
@@ -132,8 +133,13 @@ export class SprintService {
               select: { id: true, name: true, userName: true, email: true },
             },
             labels: { include: { label: true } },
+            // inclui o board de origem de cada task (multi-board)
             list: {
-              select: { id: true, title: true },
+              select: {
+                id: true,
+                title: true,
+                board: { select: { id: true, title: true } },
+              },
             },
           },
           orderBy: [{ updatedAt: 'desc' }],
@@ -152,9 +158,9 @@ export class SprintService {
     }
     return this.prisma.sprint.create({
       data: {
-        // ownerId agora é obrigatório (sprint multi-board é do dono).
-        // Por ora a sprint ainda nasce sob um board (boardId), mas já
-        // grava o dono. A lógica cross-board vem na Fase 2.
+        // Sprint é do dono (multi-board). Ainda nasce vinculada ao board de
+        // criação (boardId), mas pode receber tasks de qualquer board do
+        // dono via addTask.
         ownerId: userId,
         boardId,
         name: dto.name,
@@ -166,8 +172,7 @@ export class SprintService {
   }
 
   async update(sprintId: string, userId: string, dto: UpdateSprintDto) {
-    const sprint = await this.assertSprintAccess(sprintId, userId);
-    await this.assertBoardAdmin(sprint.boardId, userId);
+    const sprint = await this.assertSprintOwner(sprintId, userId);
 
     const data: Record<string, unknown> = {};
     if (dto.name !== undefined) data.name = dto.name;
@@ -176,18 +181,18 @@ export class SprintService {
     if (dto.endDate !== undefined) data.endDate = new Date(dto.endDate);
 
     if (dto.status !== undefined) {
-      // Só pode haver uma sprint ACTIVE por board ao mesmo tempo.
+      // Só pode haver uma sprint ACTIVE por DONO ao mesmo tempo (multi-board).
       if (dto.status === SprintStatus.ACTIVE) {
         const otherActive = await this.prisma.sprint.findFirst({
           where: {
-            boardId: sprint.boardId,
+            ownerId: sprint.ownerId,
             status: SprintStatus.ACTIVE,
             NOT: { id: sprintId },
           },
         });
         if (otherActive) {
           throw new BadRequestException(
-            'Já existe uma sprint ativa neste board. Feche ela antes de ativar outra.',
+            'Você já tem uma sprint ativa. Encerre ela antes de ativar outra.',
           );
         }
       }
@@ -209,8 +214,7 @@ export class SprintService {
   }
 
   async remove(sprintId: string, userId: string) {
-    const sprint = await this.assertSprintAccess(sprintId, userId);
-    await this.assertBoardAdmin(sprint.boardId, userId);
+    await this.assertSprintOwner(sprintId, userId);
     // Tasks têm onDelete: SetNull no schema, então ficam apenas órfãs da sprint
     // (continuam no seu board/list).
     return this.prisma.sprint.delete({ where: { id: sprintId } });
@@ -224,8 +228,7 @@ export class SprintService {
    * "essa task veio da sprint X" no histórico futuramente.
    */
   async closeSprint(sprintId: string, userId: string, dto: CloseSprintDto) {
-    const sprint = await this.assertSprintAccess(sprintId, userId);
-    await this.assertBoardAdmin(sprint.boardId, userId);
+    const sprint = await this.assertSprintOwner(sprintId, userId);
 
     if (sprint.status === SprintStatus.COMPLETED) {
       throw new BadRequestException('Sprint já está encerrada');
@@ -257,9 +260,9 @@ export class SprintService {
       if (!target) {
         throw new NotFoundException('Sprint de destino não encontrada');
       }
-      if (target.boardId !== sprint.boardId) {
+      if (target.ownerId !== sprint.ownerId) {
         throw new BadRequestException(
-          'Sprint de destino pertence a outro board',
+          'Sprint de destino pertence a outro usuário',
         );
       }
       if (target.status !== SprintStatus.PLANNED) {
@@ -328,17 +331,20 @@ export class SprintService {
   }
 
   async addTask(sprintId: string, taskId: string, userId: string) {
-    const sprint = await this.assertSprintAccess(sprintId, userId);
+    const sprint = await this.assertSprintOwner(sprintId, userId);
     if (sprint.status === SprintStatus.COMPLETED) {
       throw new BadRequestException('Sprint encerrada não aceita tasks novas');
     }
     const task = await this.prisma.task.findUnique({
       where: { id: taskId },
-      include: { list: { select: { boardId: true } } },
+      include: { list: { select: { board: { select: { ownerId: true } } } } },
     });
     if (!task) throw new NotFoundException('Task não encontrada');
-    if (task.list.boardId !== sprint.boardId) {
-      throw new BadRequestException('Task pertence a outro board');
+    // Multi-board: aceita task de QUALQUER board que o dono da sprint possui.
+    if (task.list.board.ownerId !== sprint.ownerId) {
+      throw new BadRequestException(
+        'Você só pode adicionar tasks de boards que você é dono',
+      );
     }
     return this.prisma.task.update({
       where: { id: taskId },
@@ -347,7 +353,7 @@ export class SprintService {
   }
 
   async removeTask(sprintId: string, taskId: string, userId: string) {
-    await this.assertSprintAccess(sprintId, userId);
+    await this.assertSprintOwner(sprintId, userId);
     const task = await this.prisma.task.findUnique({ where: { id: taskId } });
     if (!task) throw new NotFoundException('Task não encontrada');
     if (task.sprintId !== sprintId) {

--- a/back-end/src/sprint/sprint.service.ts
+++ b/back-end/src/sprint/sprint.service.ts
@@ -152,6 +152,10 @@ export class SprintService {
     }
     return this.prisma.sprint.create({
       data: {
+        // ownerId agora é obrigatório (sprint multi-board é do dono).
+        // Por ora a sprint ainda nasce sob um board (boardId), mas já
+        // grava o dono. A lógica cross-board vem na Fase 2.
+        ownerId: userId,
         boardId,
         name: dto.name,
         goal: dto.goal,
@@ -271,7 +275,9 @@ export class SprintService {
         status: { not: 'DONE' },
         deletedAt: null,
       },
-      select: { id: true },
+      // Inclui o board da task (via list) — com sprint multi-board, o
+      // TaskLog de cada task pertence ao board DELA, não ao da sprint.
+      select: { id: true, list: { select: { boardId: true } } },
     });
     const incompleteIds = incompleteTasks.map((t) => t.id);
 
@@ -291,10 +297,10 @@ export class SprintService {
         });
 
         await tx.taskLog.createMany({
-          data: incompleteIds.map((taskId) => ({
-            taskId,
+          data: incompleteTasks.map((t) => ({
+            taskId: t.id,
             userId,
-            boardId: sprint.boardId,
+            boardId: t.list.boardId,
             action: LogAction.TASK_SPRINT_CHANGED,
             metadata: {
               fromSprintId: sprintId,

--- a/back-end/src/task/task.service.ts
+++ b/back-end/src/task/task.service.ts
@@ -213,9 +213,24 @@ export class TaskService {
       }
     }
 
+    // Automação status -> coluna: se o status mudou e o board tem uma coluna
+    // (list) mapeada pro novo status, move a task pra ela. Se o board não
+    // tem coluna pra esse status, a task fica onde está (graceful).
+    let syncedListId: string | undefined;
+    if (isStatusChanging) {
+      const mappedList = await this.prisma.list.findFirst({
+        where: { boardId, status: dto.status as Status, isArchived: false },
+        select: { id: true },
+      });
+      if (mappedList && mappedList.id !== task.listId) {
+        syncedListId = mappedList.id;
+      }
+    }
+
     const dataToUpdate = {
       ...dto,
       ...(completedAt !== undefined && { completedAt }),
+      ...(syncedListId && { listId: syncedListId }),
     };
 
     const updated = await this.prisma.task.update({
@@ -412,6 +427,16 @@ export class TaskService {
       throw new NotFoundException('Lista de origem não encontrada');
     }
 
+    // Automação coluna -> status: se a coluna de destino tem um status
+    // mapeado, a task assume esse status (e ajusta completedAt).
+    const syncStatus =
+      targetList.status && targetList.status !== task.status
+        ? targetList.status
+        : undefined;
+    let completedAt: Date | null | undefined = undefined;
+    if (syncStatus === Status.DONE) completedAt = new Date();
+    else if (syncStatus && task.status === Status.DONE) completedAt = null;
+
     const updatedTask = await this.prisma.$transaction(async (prisma) => {
       await prisma.task.updateMany({
         where: {
@@ -433,7 +458,12 @@ export class TaskService {
 
       return prisma.task.update({
         where: { id: taskId },
-        data: { listId: newListId, position: newPosition },
+        data: {
+          listId: newListId,
+          position: newPosition,
+          ...(syncStatus && { status: syncStatus }),
+          ...(completedAt !== undefined && { completedAt }),
+        },
       });
     });
 

--- a/front-end/app/auth/login/page.tsx
+++ b/front-end/app/auth/login/page.tsx
@@ -9,7 +9,10 @@ import { Label } from "@/components/ui/label";
 import { useLogin } from "../../../hooks/auth/use-login";
 
 export default function Login() {
-  const { register, handleSubmit, errors, handleOAuth, control, isSubmitting } = useLogin();
+  // handleOAuth removido do destructuring enquanto os botões Google/Microsoft
+  // estão desabilitados (OAuth não configurado — dá 404). Re-adicionar quando
+  // o OAuth for configurado em produção.
+  const { register, handleSubmit, errors, control, isSubmitting } = useLogin();
 
   return (
     <main className="flex min-h-screen w-full bg-background">
@@ -91,33 +94,14 @@ export default function Login() {
             </div>
           </form>
 
-          <div className="my-8 flex w-full items-center gap-3 text-sm font-medium text-muted-foreground before:h-px before:flex-1 before:bg-border after:h-px after:flex-1 after:bg-border">
-            <span className="px-2">Conecte-se com</span>
-          </div>
-
-          <div className="flex justify-center gap-4">
-            <button
-              type="button"
-              onClick={() => handleOAuth('google')}
-              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-sm transition-all hover:bg-muted hover:shadow-md"
-            >
-              <svg viewBox="0 0 24 24" width="22" height="22" xmlns="http://www.w3.org/2000/svg">
-                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
-                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-              </svg>
-            </button>
-            <button
-              type="button"
-              onClick={() => handleOAuth('microsoft')}
-              className="flex h-12 w-12 items-center justify-center rounded-full border border-border bg-card text-foreground shadow-sm transition-all hover:bg-muted hover:shadow-md"
-            >
-              <svg viewBox="0 0 21 21" width="22" height="22" xmlns="http://www.w3.org/2000/svg">
-                <path d="M0 0h10v10H0z" fill="#f25022" /><path d="M11 0h10v10H11z" fill="#7fba00" /><path d="M0 11h10v10H0z" fill="#00a4ef" /><path d="M11 11h10v10H11z" fill="#ffb900" />
-              </svg>
-            </button>
-          </div>
+          {/*
+            Login social (Google/Microsoft) removido do front a pedido do PO.
+            Os provedores OAuth não estão configurados em produção (exigem
+            client ID/secret e redirect URL), então os botões davam 404.
+            Pra reativar: restaurar o bloco "Conecte-se com" + os botões
+            (commit anterior no git) e re-adicionar `handleOAuth` no
+            destructuring de useLogin() no topo deste arquivo.
+          */}
         </div>
       </div>
     </main>

--- a/front-end/app/dashboard/sprints/page.tsx
+++ b/front-end/app/dashboard/sprints/page.tsx
@@ -447,9 +447,14 @@ function SprintTaskCard({
           {task.description}
         </p>
       )}
-      <div className="flex items-center justify-between mt-2 text-[11px]">
-        <span className="text-muted-foreground/80 truncate">
-          {task.list?.title}
+      <div className="flex items-center justify-between mt-2 text-[11px] gap-2">
+        <span className="text-muted-foreground/80 truncate flex items-center gap-1.5 min-w-0">
+          {task.list?.board?.title && (
+            <span className="shrink-0 px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium">
+              {task.list.board.title}
+            </span>
+          )}
+          <span className="truncate">{task.list?.title}</span>
         </span>
         {initial ? (
           <div className="flex items-center gap-1">

--- a/front-end/app/page.tsx
+++ b/front-end/app/page.tsx
@@ -1,5 +1,9 @@
+import { redirect } from "next/navigation";
+
+// A raiz (/ em dev, /sprint em prod) não tem página própria — redireciona
+// pro dashboard. redirect() do next/navigation respeita o basePath, então
+// em prod vai pra /sprint/dashboard. O middleware (proxy.ts) cuida da auth
+// dali (manda pro login se não houver sessão).
 export default function Home() {
-  return (
-    <></>
-  );
+  redirect("/dashboard");
 }

--- a/front-end/components/layout/header/index.tsx
+++ b/front-end/components/layout/header/index.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter, usePathname } from 'next/navigation';
 import { useQuery } from "@tanstack/react-query";
 import { removeCookie } from "@/lib/utils/session-cookie";
+import { withBasePath } from "@/lib/base-path";
 import { getUserProfile } from "@/lib/actions/profile";
 import styles from "./style.module.css";
 import { useSprintStore } from "@/stores/use-sprint-store";
@@ -47,7 +48,7 @@ export default function Header() {
     // react-query e desmonta todos os componentes/forms do dashboard. Sem
     // isso, queries em flight com cookie já apagado podem deixar estado
     // sujo e travar o próximo submit de login.
-    window.location.href = "/auth/login";
+    window.location.href = withBasePath("/auth/login");
   };
 
   return (

--- a/front-end/features/sprints/add-task-dialog.tsx
+++ b/front-end/features/sprints/add-task-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { Search, Plus } from "lucide-react";
@@ -14,11 +14,20 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { getAllList } from "@/lib/actions/list";
+import { getBoards } from "@/lib/actions/board";
 import { addTaskToSprint } from "@/lib/actions/sprint";
 import type { Task } from "@/types/task";
 
 interface AddTaskDialogProps {
+  /** Board padrão (o selecionado na sidebar). O usuário pode trocar. */
   boardId: string;
   sprintId: string;
   isOpen: boolean;
@@ -34,11 +43,26 @@ export function AddTaskDialog({
   const queryClient = useQueryClient();
   const [search, setSearch] = useState("");
   const [adding, setAdding] = useState<string | null>(null);
+  // Board que está sendo navegado (multi-board: dá pra puxar de vários).
+  const [browseBoardId, setBrowseBoardId] = useState(boardId);
+
+  useEffect(() => {
+    if (boardId) setBrowseBoardId(boardId);
+  }, [boardId]);
+
+  const { data: boardsData } = useQuery({
+    queryKey: ["boards"],
+    queryFn: getBoards,
+    enabled: isOpen,
+    staleTime: 30_000,
+  });
+  const boards =
+    boardsData?.success && boardsData.data ? boardsData.data : [];
 
   const { data, isLoading } = useQuery({
-    queryKey: ["board-lists", boardId],
-    queryFn: () => getAllList(boardId),
-    enabled: isOpen && !!boardId,
+    queryKey: ["board-lists", browseBoardId],
+    queryFn: () => getAllList(browseBoardId),
+    enabled: isOpen && !!browseBoardId,
   });
 
   const candidates = useMemo<Task[]>(() => {
@@ -63,8 +87,11 @@ export function AddTaskDialog({
     const r = await addTaskToSprint(sprintId, task.id);
     setAdding(null);
     if (r.success) {
-      queryClient.invalidateQueries({ queryKey: ["sprint-active", boardId] });
-      queryClient.invalidateQueries({ queryKey: ["board-lists", boardId] });
+      // sprint-active é por-dono agora; invalida todas as variações
+      queryClient.invalidateQueries({ queryKey: ["sprint-active"] });
+      queryClient.invalidateQueries({
+        queryKey: ["board-lists", browseBoardId],
+      });
       toast.success(`"${task.title}" adicionada à sprint`);
     } else {
       toast.error(r.error || "Erro ao adicionar");
@@ -77,11 +104,26 @@ export function AddTaskDialog({
         <DialogHeader>
           <DialogTitle>Adicionar task à sprint</DialogTitle>
           <DialogDescription>
-            Selecione uma task do board que ainda não está em sprint.
+            Escolha um board e adicione tasks que ainda não estão em sprint.
+            Você pode puxar de vários boards.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3 mt-2">
+          {/* Seletor de board (multi-board) */}
+          <Select value={browseBoardId} onValueChange={setBrowseBoardId}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Escolha o board" />
+            </SelectTrigger>
+            <SelectContent>
+              {boards.map((b) => (
+                <SelectItem key={b.id} value={b.id}>
+                  {b.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
@@ -100,7 +142,7 @@ export function AddTaskDialog({
             ) : filtered.length === 0 ? (
               <div className="text-xs text-muted-foreground italic py-6 text-center">
                 {candidates.length === 0
-                  ? "Sem tasks elegíveis (todas já estão em uma sprint ou arquivadas)"
+                  ? "Sem tasks elegíveis neste board (todas já estão em uma sprint ou arquivadas)"
                   : "Nenhuma task casa com a busca"}
               </div>
             ) : (

--- a/front-end/features/sprints/history/sprint-history.tsx
+++ b/front-end/features/sprints/history/sprint-history.tsx
@@ -62,6 +62,11 @@ function TaskRow({
       >
         {task.title}
       </span>
+      {task.list?.board?.title && (
+        <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground font-medium hidden sm:inline">
+          {task.list.board.title}
+        </span>
+      )}
       <span className="text-xs text-muted-foreground hidden md:flex items-center gap-1">
         <User size={12} />
         {assigneeLabel(task.assignee)}

--- a/front-end/hooks/auth/use-login.ts
+++ b/front-end/hooks/auth/use-login.ts
@@ -5,6 +5,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { login } from "@/lib/actions/auth";
+import { withBasePath } from "@/lib/base-path";
 import { LoginFormData, loginSchema } from "../../app/auth/login/login-schema";
 
 export function useLogin() {
@@ -45,7 +46,7 @@ export function useLogin() {
   };
 
   const handleOAuth = (provider: string) => {
-    window.location.href = `/api/v1/auth/${provider}`;
+    window.location.href = withBasePath(`/api/v1/auth/${provider}`);
   };
 
   return {

--- a/front-end/image-loader.ts
+++ b/front-end/image-loader.ts
@@ -1,0 +1,15 @@
+// Custom loader pro next/image respeitar o basePath em produção.
+//
+// Problema: <Image src="/images/x.png"> com string não prefixa o basePath
+// sozinho. O otimizador (/_next/image) dá 400 sob basePath no standalone,
+// e com unoptimized o src vira /images/... (sem /sprint) → 404.
+//
+// Este loader prefixa o /sprint em produção (igual ao basePath do
+// next.config) e devolve a imagem crua. URLs absolutas (ex: avatares
+// externos) passam sem alteração.
+const basePath = process.env.NODE_ENV === "production" ? "/sprint" : "";
+
+export default function imageLoader({ src }: { src: string }): string {
+  if (/^https?:\/\//.test(src)) return src;
+  return `${basePath}${src}`;
+}

--- a/front-end/lib/actions/sprint.ts
+++ b/front-end/lib/actions/sprint.ts
@@ -34,6 +34,8 @@ export interface SprintTask extends Task {
   list: {
     id: string;
     title: string;
+    // board de origem (multi-board) — incluído pelo getActive
+    board?: { id: string; title: string };
   };
 }
 
@@ -52,7 +54,8 @@ export interface HistorySprintTask {
     userName: string | null;
     email: string | null;
   } | null;
-  list: { id: string; title: string };
+  // board de origem (multi-board) — incluído pelo getHistory
+  list: { id: string; title: string; board?: { id: string; title: string } };
 }
 
 export interface HistorySprint extends Sprint {

--- a/front-end/lib/base-path.ts
+++ b/front-end/lib/base-path.ts
@@ -1,0 +1,14 @@
+/**
+ * basePath do app. Vazio em dev (localhost:3001/), "/sprint" em produção
+ * (servido em bayarea.dataiesb.com/sprint — ver basePath no next.config).
+ *
+ * O Next prefixa o basePath sozinho em <Link>, router.push e redirect() do
+ * next/navigation. Mas APIs do browser (window.location) NÃO conhecem o
+ * basePath — então redirects via window.location precisam usar withBasePath().
+ */
+export const BASE_PATH =
+  process.env.NODE_ENV === "production" ? "/sprint" : "";
+
+export function withBasePath(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -10,6 +10,12 @@ const nextConfig: NextConfig = {
   // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
   // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
   basePath: isDev ? undefined : '/sprint',
+  // Otimizador de imagem do Next (/_next/image) retorna 400 sob basePath
+  // no deploy standalone — ele tenta buscar a imagem em /images (sem o
+  // /sprint) e falha. unoptimized faz o <Image> servir o arquivo cru em
+  // /sprint/images/... (que existe), corrigindo os logos quebrados.
+  // São assets estáticos pequenos, otimização não faz diferença aqui.
+  images: { unoptimized: true },
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `

--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -5,6 +5,11 @@ const isDev = process.env.NODE_ENV !== 'production';
 const nextConfig: NextConfig = {
   output: 'standalone',
   poweredByHeader: false,
+  // Em produção o app é servido sob https://bayarea.dataiesb.com/sprint.
+  // basePath faz o Next prefixar todas as URLs internas (links, redirects,
+  // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
+  // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
+  basePath: isDev ? undefined : '/sprint',
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `

--- a/front-end/next.config.ts
+++ b/front-end/next.config.ts
@@ -10,12 +10,13 @@ const nextConfig: NextConfig = {
   // assets /_next) com /sprint. Em dev fica vazio pra rodar em localhost:3001/.
   // Requer que o ingress passe /sprint/* pro front SEM remover o prefixo.
   basePath: isDev ? undefined : '/sprint',
-  // Otimizador de imagem do Next (/_next/image) retorna 400 sob basePath
-  // no deploy standalone — ele tenta buscar a imagem em /images (sem o
-  // /sprint) e falha. unoptimized faz o <Image> servir o arquivo cru em
-  // /sprint/images/... (que existe), corrigindo os logos quebrados.
-  // São assets estáticos pequenos, otimização não faz diferença aqui.
-  images: { unoptimized: true },
+  // Custom loader (image-loader.ts) prefixa o basePath /sprint no src das
+  // imagens em produção. Sem isso o <Image> renderiza /images/... sem o
+  // /sprint → 404 (o otimizador padrão também dava 400 sob basePath).
+  images: {
+    loader: "custom",
+    loaderFile: "./image-loader.ts",
+  },
   async headers() {
     // TODO: Ao implementar TLS, colocar "upgrade-insecure-requests;"
     const cspHeader = `

--- a/front-end/proxy.ts
+++ b/front-end/proxy.ts
@@ -42,11 +42,15 @@ export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set('x-nonce', nonce);
 
+  // nextUrl.clone() preserva o basePath (/sprint em prod). Setar .pathname
+  // e redirecionar mantém o prefixo — diferente de new URL(path, request.url),
+  // que gera caminho absoluto SEM basePath e quebra no deploy em sub-path.
   const isProtectedRoute = !request.nextUrl.pathname.startsWith('/auth');
   if (isProtectedRoute) {
     const tokenCookie = request.cookies.get('sprinttacker-session');
     if (!tokenCookie?.value) {
-      const loginURL = new URL('/auth/login', request.url);
+      const loginURL = request.nextUrl.clone();
+      loginURL.pathname = '/auth/login';
       const redirectResponse = NextResponse.redirect(loginURL);
       redirectResponse.headers.set('Content-Security-Policy', sanitizedCspHeader);
       return redirectResponse;
@@ -55,7 +59,8 @@ export function proxy(request: NextRequest) {
 
   const homeToDashboard = request.nextUrl.pathname === '/';
   if (homeToDashboard) {
-    const dashboardURL = new URL('/dashboard', request.url);
+    const dashboardURL = request.nextUrl.clone();
+    dashboardURL.pathname = '/dashboard';
     const redirectResponse = NextResponse.redirect(dashboardURL);
     redirectResponse.headers.set('Content-Security-Policy', sanitizedCspHeader);
     return redirectResponse;

--- a/k8s/prod/backend.yaml
+++ b/k8s/prod/backend.yaml
@@ -18,6 +18,15 @@ spec:
           image: 248189947068.dkr.ecr.us-east-1.amazonaws.com/bayarea-sprint-backend-prod:latest
           ports:
             - containerPort: 3000
+          # Hardening (a imagem já roda como USER appuser, não-root)
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: NODE_ENV
               value: "production"

--- a/k8s/prod/frontend.yaml
+++ b/k8s/prod/frontend.yaml
@@ -18,6 +18,15 @@ spec:
           image: 248189947068.dkr.ecr.us-east-1.amazonaws.com/bayarea-sprint-frontend-prod:latest
           ports:
             - containerPort: 3000
+          # Hardening (a imagem já roda como USER appuser, não-root)
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
           env:
             - name: BASE_URL_API
               value: "https://bayarea.dataiesb.com/sprint/api"


### PR DESCRIPTION
Fecha os 2 alertas **Semgrep** `allow-privilege-escalation-no-securitycontext` em `k8s/prod/backend.yaml` e `k8s/prod/frontend.yaml`.

### O que adiciona (container-level, nos 2 Deployments)
```yaml
securityContext:
  allowPrivilegeEscalation: false   # o achado do Semgrep
  runAsNonRoot: true                # imagens já usam USER appuser (Dockerfile)
  capabilities:
    drop: ["ALL"]
  seccompProfile:
    type: RuntimeDefault
```

### Decisões conservadoras (pra não arriscar o rollout de prod)
- **Sem `runAsUser` fixo** — o `appuser` é criado com `adduser --system` (uid automático); fixar um número poderia descasar do dono dos arquivos (`--chown=appuser`) durante o rolling update. `runAsNonRoot: true` já garante não-root usando o uid real da imagem.
- **Sem `readOnlyRootFilesystem`** — a app pode escrever em temp; evitei quebra.

Validado: YAML parseia, `allowPrivilegeEscalation:false` presente nos 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)