### PR TITLE
fix(front): destrava o deploy de prod — type error no burndown chart

### DIFF
--- a/front-end/features/sprints/burndown/chart-area-interactive.tsx
+++ b/front-end/features/sprints/burndown/chart-area-interactive.tsx
@@ -234,6 +234,8 @@ export function ChartAreaInteractive() {
               content={
                 <ChartTooltipContent
                   labelFormatter={(value) => {
+                    // value pode vir undefined do recharts; evita new Date(undefined)
+                    if (value == null) return ""
                     return new Date(value).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",


### PR DESCRIPTION
## O que aconteceu

O merge do #203 disparou o **CI/CD Prod**: o **backend deployou com sucesso**, mas o **frontend falhou no `next build`**:

```
chart-area-interactive.tsx:237
Type 'undefined' is not assignable to type 'string | number'.
  labelFormatter={(value) => new Date(value).toLocaleDateString(...)}
```

O componente de **burndown** (veio da `dev`, nunca tinha passado pelo build de prod) usa `new Date(value)` num `labelFormatter` cujo `value` pode ser `undefined` (tipos do recharts 3.8.1 no lockfile regenerado).

## Fix

Guard mínimo: `if (value == null) return ""` antes do `new Date`.

## Validação

`tsc --noEmit`: **0 erros** com node_modules resolvido do lockfile atual (o mesmo do Docker).

**Ao mergear, o CI/CD Prod roda de novo e completa o deploy do frontend.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)