### PR TITLE
fix(front): build Docker determinístico (usa pnpm-lock) — destrava o deploy de vez

### DIFF
--- a/front-end/Dockerfile
+++ b/front-end/Dockerfile
@@ -6,17 +6,21 @@ FROM node:22-slim AS build
 # Define o diretório de trabalho dentro do container
 WORKDIR /app
 
-# Copia os arquivos de dependências (package.json e package-lock.json) para o container
-COPY package*.json ./
+# Copia os arquivos de dependências (package.json e pnpm-lock.yaml) para o container
+COPY package.json pnpm-lock.yaml ./
 
-# Instala as dependências de forma limpa
-RUN npm install --quiet --no-fund --loglevel=error
+# Instala as dependências EXATAS do lockfile (build reprodutível).
+# Antes usávamos `npm install`, que ignorava o pnpm-lock.yaml e resolvia
+# versões novas a cada build — o que quebrava o deploy quando um transitivo
+# (ex: recharts) mudava tipos entre builds.
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate \
+  && pnpm install --frozen-lockfile
 
 # Copia todos os arquivos do projeto para o container
 COPY . .
 
 # Executa o comando de build para gerar os arquivos otimizados da aplicação
-RUN npm run build
+RUN pnpm run build
 
 # ---------------------
 # Etapa final: produção

--- a/front-end/features/sprints/burndown/chart-area-interactive.tsx
+++ b/front-end/features/sprints/burndown/chart-area-interactive.tsx
@@ -233,9 +233,11 @@ export function ChartAreaInteractive() {
               cursor={false}
               content={
                 <ChartTooltipContent
-                  labelFormatter={(value) => {
-                    // value pode vir undefined do recharts; evita new Date(undefined)
-                    if (value == null) return ""
+                  labelFormatter={(value: unknown) => {
+                    // O tipo de `value` varia entre versões do recharts
+                    // (undefined/bigint já quebraram o build). Normaliza
+                    // pra string|number antes do new Date.
+                    if (typeof value !== "string" && typeof value !== "number") return ""
                     return new Date(value).toLocaleDateString("en-US", {
                       month: "short",
                       day: "numeric",


### PR DESCRIPTION
## Causa raiz (por que o deploy quebrou 2x com erros diferentes)

O `front-end/Dockerfile` copiava só `package*.json` e rodava **`npm install`** — o **`pnpm-lock.yaml` nem entrava no build**. Cada build resolvia dependências livremente na hora:

- Build 1 (#203): recharts com tipos que incluem `undefined` → quebrou
- Build 2 (#204): outra resolução, tipos com `bigint` → quebrou de novo
- Meu `tsc` local (que usa o lockfile) passava sempre — validava outra árvore de deps 🤦

## Fix

1. **Dockerfile determinístico:** `COPY package.json pnpm-lock.yaml` + `corepack pnpm@9.15.9` + **`pnpm install --frozen-lockfile`** + `pnpm run build`. O build passa a usar exatamente as versões do lockfile (as mesmas que o type-check local valida).
2. **Guard robusto no chart:** `labelFormatter` normaliza `value` para `string|number` antes do `new Date` — imune a futuras mudanças de tipo do recharts.

## Validação

**`docker build front-end/` completo rodado localmente: exit 0** (mesmo build do CI — pnpm frozen + next build + type-check).

Runtime não muda: a etapa de produção continua copiando o standalone (`server.js`) igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)