### PR TITLE
fix(sec): senha não vaza mais pra URL no login + tratamento de sessão expirada

### DIFF
--- a/front-end/app/auth/forgot-password/page.tsx
+++ b/front-end/app/auth/forgot-password/page.tsx
@@ -5,9 +5,13 @@ import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { ArrowLeft } from "lucide-react";
 import { useForgotPassword } from "@/hooks/auth/use-forgot-password";
+import { useScrubUrlQuery } from "@/hooks/auth/use-scrub-url-query";
 
 export default function ForgotPassword() {
   const { register, onSubmit, formState: { errors, isSubmitting } } = useForgotPassword();
+
+  // Limpa credenciais que tenham vindo na URL (links antigos do histórico).
+  useScrubUrlQuery();
 
   return (
     <main className="flex min-h-screen w-full bg-background">
@@ -40,7 +44,8 @@ export default function ForgotPassword() {
             Para redefinir sua senha, insira seu e-mail cadastrado e clique em &quot;Enviar e-mail&quot;. Você receberá um e-mail com instruções.
           </p>
 
-          <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+          {/* method="POST": fallback pré-hidratação não pode ser GET (e-mail na URL) */}
+          <form method="POST" className="flex flex-col gap-4" onSubmit={onSubmit}>
             <div className="space-y-1">
               <Input
                 type="email"

--- a/front-end/app/auth/forgot-password/verify/page.tsx
+++ b/front-end/app/auth/forgot-password/verify/page.tsx
@@ -5,9 +5,13 @@ import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { ArrowLeft } from "lucide-react";
 import { useVerifyReset } from "@/hooks/auth/use-verify-reset";
+import { useScrubUrlQuery } from "@/hooks/auth/use-scrub-url-query";
 
 export default function VerifyCodeResetPassword() {
   const { step, verifyForm, resetForm, onVerify, onReset } = useVerifyReset();
+
+  // Limpa credenciais/códigos que tenham vindo na URL (links antigos do histórico).
+  useScrubUrlQuery();
 
   return (
     <main className="flex min-h-screen w-full bg-background">
@@ -39,12 +43,14 @@ export default function VerifyCodeResetPassword() {
               <p className="mb-8 text-center text-sm leading-relaxed text-foreground">
                 Digite o código de verificação enviado para seu e-mail para continuar com a redefinição da senha.
               </p>
-              <form className="flex flex-col gap-4" onSubmit={onVerify}>
+              {/* method="POST": fallback pré-hidratação não pode ser GET (código na URL) */}
+              <form method="POST" className="flex flex-col gap-4" onSubmit={onVerify}>
                 <div className="space-y-1">
                   <Input
                     type="text"
                     placeholder="Código de verificação"
                     maxLength={8}
+                    autoComplete="one-time-code"
                     className="border-input bg-card text-center text-lg font-bold tracking-[2px] text-foreground focus-visible:ring-[#e02b2b]"
                     {...verifyForm.register("code")}
                   />
@@ -65,11 +71,13 @@ export default function VerifyCodeResetPassword() {
               <p className="mb-8 text-center text-sm leading-relaxed text-foreground">
                 Agora você pode definir uma nova senha para sua conta.
               </p>
-              <form className="flex flex-col gap-4" onSubmit={onReset}>
+              {/* method="POST": fallback pré-hidratação não pode ser GET (senha nova na URL) */}
+              <form method="POST" className="flex flex-col gap-4" onSubmit={onReset}>
                 <div className="space-y-1">
                   <Input
                     type="password"
                     placeholder="Nova senha"
+                    autoComplete="new-password"
                     className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                     {...resetForm.register("newPassword")}
                   />
@@ -79,6 +87,7 @@ export default function VerifyCodeResetPassword() {
                   <Input
                     type="password"
                     placeholder="Confirmar nova senha"
+                    autoComplete="new-password"
                     className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                     {...resetForm.register("confirmNewPassword")}
                   />

--- a/front-end/app/auth/login/page.tsx
+++ b/front-end/app/auth/login/page.tsx
@@ -7,12 +7,16 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useLogin } from "../../../hooks/auth/use-login";
+import { useScrubUrlQuery } from "../../../hooks/auth/use-scrub-url-query";
 
 export default function Login() {
   // handleOAuth removido do destructuring enquanto os botões Google/Microsoft
   // estão desabilitados (OAuth não configurado — dá 404). Re-adicionar quando
   // o OAuth for configurado em produção.
   const { register, handleSubmit, errors, control, isSubmitting } = useLogin();
+
+  // Limpa credenciais que tenham vindo na URL (links antigos do histórico).
+  useScrubUrlQuery();
 
   return (
     <main className="flex min-h-screen w-full bg-background">
@@ -38,10 +42,14 @@ export default function Login() {
             ACESSE SUA CONTA
           </h1>
 
-          <form className="flex flex-col gap-5" onSubmit={handleSubmit}>
+          {/* method="POST": se o submit acontecer ANTES do React hidratar
+              (JS lento/bloqueado), o fallback nativo do browser vira POST —
+              sem isso o default é GET e as credenciais vazam pra URL/logs. */}
+          <form method="POST" className="flex flex-col gap-5" onSubmit={handleSubmit}>
             <div className="space-y-1">
               <Input
                 placeholder="Nome de usuário ou e-mail"
+                autoComplete="username"
                 className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                 {...register("email")}
               />
@@ -52,6 +60,7 @@ export default function Login() {
               <Input
                 type="password"
                 placeholder="Senha"
+                autoComplete="current-password"
                 className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                 {...register("password")}
               />

--- a/front-end/app/auth/register/page.tsx
+++ b/front-end/app/auth/register/page.tsx
@@ -7,9 +7,13 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useRegister } from "../../../hooks/auth/use-register";
+import { useScrubUrlQuery } from "../../../hooks/auth/use-scrub-url-query";
 
 export default function Register() {
   const { registerField, handleSubmit, errors, password, isSubmitting, passwordRequirements, control } = useRegister();
+
+  // Limpa credenciais que tenham vindo na URL (links antigos do histórico).
+  useScrubUrlQuery();
 
   const getReqClass = (met: boolean) => {
     if (!password) return "text-muted-foreground";
@@ -39,7 +43,8 @@ export default function Register() {
             CRIE SUA CONTA
           </h1>
 
-          <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
+          {/* method="POST": fallback pré-hidratação não pode ser GET (senha na URL) */}
+          <form method="POST" className="flex flex-col gap-4" onSubmit={handleSubmit}>
             <div className="space-y-1">
               <Input
                 placeholder="Nome completo"
@@ -85,6 +90,7 @@ export default function Register() {
                 <Input
                   type="password"
                   placeholder="Senha"
+                  autoComplete="new-password"
                   className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                   {...registerField("password")}
                 />
@@ -93,6 +99,7 @@ export default function Register() {
                 <Input
                   type="password"
                   placeholder="Confirme a senha"
+                  autoComplete="new-password"
                   className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                   {...registerField("confirmPassword")}
                 />

--- a/front-end/hooks/auth/use-login.ts
+++ b/front-end/hooks/auth/use-login.ts
@@ -29,8 +29,6 @@ export function useLogin() {
     try {
       const result = await login(data.email, data.password, data.rememberMe);
 
-      console.log(result);
-
       if (result && (result.success || !result.error)) {
         router.push("/dashboard");
       } else {
@@ -41,8 +39,9 @@ export function useLogin() {
     }
   };
 
-  const onErrors = (err: any) => {
-    console.log(JSON.stringify(err, null, 2));
+  const onErrors = () => {
+    // Erros de validação já aparecem inline nos campos; nada a logar
+    // (logar o objeto de erro é um ralo pronto pra vazar dados de form).
   };
 
   const handleOAuth = (provider: string) => {

--- a/front-end/hooks/auth/use-register.ts
+++ b/front-end/hooks/auth/use-register.ts
@@ -52,8 +52,9 @@ export function useRegister() {
     }
   };
 
-  const onErrors = (err: any) => {
-    console.log(JSON.stringify(err, null, 2));
+  const onErrors = () => {
+    // Erros de validação já aparecem inline nos campos; nada a logar
+    // (logar o objeto de erro é um ralo pronto pra vazar dados de form).
   };
 
   return {

--- a/front-end/hooks/auth/use-scrub-url-query.ts
+++ b/front-end/hooks/auth/use-scrub-url-query.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Remove a query string da URL ao montar a página.
+ *
+ * As rotas de /auth não usam query string legítima — mas versões antigas dos
+ * forms (sem method="POST") faziam submit nativo GET e vazavam credenciais
+ * pra URL (?email=...&password=...). Links assim ainda existem em históricos
+ * e bookmarks; este hook limpa a barra de endereço assim que o JS carrega,
+ * pra senha não ficar visível nem seguir como referer.
+ *
+ * Usa window.location.pathname (e não usePathname) de propósito: o pathname
+ * do browser já inclui o basePath /sprint.
+ */
+export function useScrubUrlQuery() {
+  useEffect(() => {
+    if (window.location.search) {
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, []);
+}

--- a/front-end/lib/api/axios.ts
+++ b/front-end/lib/api/axios.ts
@@ -34,4 +34,35 @@ api.interceptors.request.use(async (config) => {
   return config;
 });
 
+/** Erro lançado quando a API devolve HTML no lugar de JSON (sessão expirada). */
+export const SESSION_EXPIRED_MESSAGE =
+  'Sessão expirada. Faça login novamente.';
+
+function looksLikeHtml(data: unknown): boolean {
+  return (
+    typeof data === 'string' && /^\s*(<!doctype\s|<html[\s>])/i.test(data)
+  );
+}
+
+// O CloudFront na frente do site tem um Custom Error Response que converte
+// 403 da API em "200 + index.html" (regra de SPA aplicada também às rotas
+// de API). Quando o JWT expira, a chamada "dá certo" (200) mas o body é
+// HTML — e quem consome quebra com "unexpected character" ao tratar como
+// JSON. Este interceptor detecta o HTML e converte num erro claro de
+// sessão expirada, nos DOIS caminhos (200-com-HTML e erro-com-HTML).
+api.interceptors.response.use(
+  (response) => {
+    if (looksLikeHtml(response.data)) {
+      return Promise.reject(new Error(SESSION_EXPIRED_MESSAGE));
+    }
+    return response;
+  },
+  (error) => {
+    if (axios.isAxiosError(error) && looksLikeHtml(error.response?.data)) {
+      return Promise.reject(new Error(SESSION_EXPIRED_MESSAGE));
+    }
+    return Promise.reject(error);
+  },
+);
+
 export default api;


### PR DESCRIPTION
## 🔴 Bug 1 (crítico, aconteceu em prod): credenciais na URL

Login entregou `/auth/login?email=...&password=...`. Causa: os `<form>` de auth **não tinham `method`** → padrão HTML é **GET na própria URL**. Quando o submit acontece **antes do React hidratar** (JS lento/bloqueado), o browser faz o submit nativo e as credenciais vazam pra: barra de endereço, histórico, logs do LB/CloudFront e referer.

**Fixes:**
- `method="POST"` nos **5 forms de auth** — o fallback pré-hidratação passa a mandar credenciais **no corpo**, nunca na URL. *Verificado empiricamente: POST numa rota de página do App Router re-renderiza a página (200), sem query, sem redirect; o `handleSubmit` do RHF continua interceptando normalmente pós-hidratação.*
- **`useScrubUrlQuery()`** nas 4 páginas de auth — URLs antigas com credenciais (histórico/bookmark) são limpas da barra de endereço no load.
- `autoComplete` correto (`username`/`current-password`/`new-password`/`one-time-code`).
- Remoção de `console.log` residuais nos hooks de auth.

## Bug 2: "unexpected character" com token expirado

O CloudFront tem Custom Error Response que converte **403 da API em `200 + index.html`** — o front recebia HTML no caminho de *sucesso* e quebrava ao tratar como JSON. Interceptor novo no axios detecta body HTML (nos 2 caminhos) e converte em erro claro: **"Sessão expirada. Faça login novamente."**

> ⚠️ Este é o ajuste que o DevOps aplicou manualmente — **agora versionado no repo** (a versão dele seria sobrescrita no próximo deploy).

## Validação
- `docker build` completo (idêntico ao CI): **exit 0**
- **Verificação adversarial multi-agente**: 3 céticos independentes tentaram refutar cada fix (1 rodou dev server e testou o POST pré-hidratação empiricamente) + varredura confirmou que todos os demais forms do app são pós-hidratação e sem credenciais (PASS)

## 🚀 Pós-merge (importante)
1. **Invalidar o cache do CloudFront** em `/sprint/auth/*` — senão o HTML antigo (form sem method) continua servido.
2. **DevOps:** o Custom Error Response 403→index.html deve ser **restrito ao SPA e nunca aplicado a `/sprint/api/*`** (o conserto certo é na infra; o interceptor é defesa em profundidade).
3. Time: purgar/rotacionar logs que contenham a URL vazada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)