### PR TITLE
docs: 'passe de bastão' → 'guia de continuidade'

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
-# 🤝 Passe de Bastão — Sprint Tracker
+# 🤝 Guia de Continuidade — Sprint Tracker
 
-> Guia de continuidade para a comunidade da **Fábrica Bay Area / IESB**.
+> Para a comunidade da **Fábrica Bay Area / IESB**.
 > O projeto foi **entregue e está em produção**. Este documento existe para que qualquer pessoa nova consiga entender, rodar, evoluir e manter o Sprint Tracker **sem depender de quem construiu**.
 
 **Status:** ✅ Entregue · 🟢 Em produção em [bayarea.dataiesb.com/sprint](https://bayarea.dataiesb.com/sprint)
@@ -107,4 +107,4 @@ Abra uma **issue** no repositório descrevendo o contexto — assim a resposta f
 
 ---
 
-*O bastão é da comunidade. Bom código! 🚀*
+*O projeto agora é da comunidade. Bom código! 🚀*


### PR DESCRIPTION
Ajuste de linguagem por feedback do PO: a expressão "passe de bastão" soava literal demais. Trocada por "continuidade", que comunica a mesma ideia de forma mais direta.

Só texto — nenhuma mudança de conteúdo ou código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)