### PR TITLE
fix(front): cadastro falhava em silêncio quando a senha era inválida

### DIFF
--- a/front-end/app/auth/register/page.tsx
+++ b/front-end/app/auth/register/page.tsx
@@ -94,6 +94,7 @@ export default function Register() {
                   className="border-input bg-card text-foreground focus-visible:ring-[#e02b2b]"
                   {...registerField("password")}
                 />
+                {errors.password && <span className="text-xs text-red-500">{errors.password.message}</span>}
               </div>
               <div className="space-y-1">
                 <Input
@@ -108,6 +109,9 @@ export default function Register() {
             </div>
 
             <div className="rounded-lg border border-border bg-muted p-3 text-[12px] leading-relaxed">
+              <div className={`flex items-center gap-1.5 ${getReqClass(passwordRequirements.hasMinLength)}`}>
+                <span>{passwordRequirements.hasMinLength ? '✔' : '✖'}</span> Pelo menos 8 caracteres
+              </div>
               <div className={`flex items-center gap-1.5 ${getReqClass(passwordRequirements.hasUppercase)}`}>
                 <span>{passwordRequirements.hasUppercase ? '✔' : '✖'}</span> Pelo menos 1 letra maiúscula
               </div>

--- a/front-end/hooks/auth/use-register.ts
+++ b/front-end/hooks/auth/use-register.ts
@@ -31,6 +31,10 @@ export function useRegister() {
   const password = watch("password", "");
 
   const passwordRequirements = {
+    // O schema exige 8+ caracteres, mas o painel de requisitos não mostrava
+    // isso: dava pra ver os 4 itens verdes com uma senha curta, clicar em
+    // Cadastrar e nada acontecer (o zod barrava em silêncio).
+    hasMinLength: password.length >= 8,
     hasUppercase: /[A-Z]/.test(password),
     hasLowercase: /[a-z]/.test(password),
     hasNumber: /[0-9]/.test(password),


### PR DESCRIPTION
## O bug (reproduzido na prática)

Usuário preenche o cadastro, clica em **Cadastrar** e **nada acontece** — nenhuma mensagem, nenhum erro. Parece que o botão está morto.

## Causa

Duas falhas somadas no formulário de registro:

1. **O campo `password` era o único sem exibição de erro.** Todos os outros campos (nome, usuário, e-mail, confirmações, termos) renderizam a mensagem do zod. A senha barrava a submissão **em silêncio absoluto**.
2. **O painel de requisitos não listava "mínimo 8 caracteres"**, embora o schema exija. Ou seja: dava pra digitar uma senha curta como `Ab1!` , ver **os 4 requisitos verdes**, clicar em Cadastrar — e o formulário recusar sem dizer nada.

**A API nunca teve problema:** `POST /auth/signup` responde 201 normalmente. Era 100% UX do front.

## Fix

- Adiciona `{errors.password && ...}` no campo de senha.
- Adiciona "Pelo menos 8 caracteres" ao painel de requisitos (com o mesmo ✔/✖ dos demais).

## Validação
`docker build` completo (idêntico ao CI): **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)