### PR TITLE
fix(front): login só entrava na 2ª tentativa + checkbox duplicado

### DIFF
--- a/front-end/app/auth/login/page.tsx
+++ b/front-end/app/auth/login/page.tsx
@@ -8,8 +8,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useLogin } from "../../../hooks/auth/use-login";
 import { useScrubUrlQuery } from "../../../hooks/auth/use-scrub-url-query";
+import { useHydrated } from "../../../hooks/use-hydrated";
 
 export default function Login() {
+  const hydrated = useHydrated();
   // handleOAuth removido do destructuring enquanto os botões Google/Microsoft
   // estão desabilitados (OAuth não configurado — dá 404). Re-adicionar quando
   // o OAuth for configurado em produção.
@@ -85,9 +87,12 @@ export default function Login() {
               </Label>
             </div>
 
+            {/* disabled até hidratar: um clique antes disso dispararia o
+                submit nativo do form, recarregando a página (o tema pisca de
+                claro pra escuro) sem efetuar o login. */}
             <button
               type="submit"
-              disabled={isSubmitting}
+              disabled={!hydrated || isSubmitting}
               className="mt-2 w-full rounded-lg bg-[#e02b2b] p-3 text-base font-bold text-white transition-colors hover:bg-[#c92525] disabled:opacity-50"
             >
               {isSubmitting ? "Carregando..." : "Entrar"}

--- a/front-end/app/auth/register/page.tsx
+++ b/front-end/app/auth/register/page.tsx
@@ -8,8 +8,10 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import { useRegister } from "../../../hooks/auth/use-register";
 import { useScrubUrlQuery } from "../../../hooks/auth/use-scrub-url-query";
+import { useHydrated } from "../../../hooks/use-hydrated";
 
 export default function Register() {
+  const hydrated = useHydrated();
   const { registerField, handleSubmit, errors, password, isSubmitting, passwordRequirements, control } = useRegister();
 
   // Limpa credenciais que tenham vindo na URL (links antigos do histórico).
@@ -147,9 +149,10 @@ export default function Register() {
               {errors.agreeTerms && <p className="text-xs text-red-500">{errors.agreeTerms.message}</p>}
             </div>
 
+            {/* disabled até hidratar — ver comentário na tela de login */}
             <button
               type="submit"
-              disabled={isSubmitting}
+              disabled={!hydrated || isSubmitting}
               className="mt-2 w-full rounded-lg bg-[#e02b2b] p-3 text-base font-bold text-white transition-colors hover:bg-[#c92525] disabled:opacity-50"
             >
               {isSubmitting ? "Carregando..." : "Cadastrar"}

--- a/front-end/components/ui/checkbox.tsx
+++ b/front-end/components/ui/checkbox.tsx
@@ -14,7 +14,15 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input transition-colors outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        // O Radix marca o estado com data-state="checked". As classes
+        // data-checked:* que existiam aqui nunca aplicavam (CSS morto).
+        "data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        // O Radix renderiza, ao lado do botão, um <input type="checkbox">
+        // nativo (para submit de formulário) que deveria ficar invisível.
+        // Em alguns navegadores/ajustes de acessibilidade ele aparece — daí
+        // as DUAS caixinhas na tela. Escondemos explicitamente.
+        "[&~input[type=checkbox]]:sr-only",
         className
       )}
       {...props}

--- a/front-end/hooks/use-hydrated.ts
+++ b/front-end/hooks/use-hydrated.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Retorna `false` no HTML renderizado no servidor e `true` assim que o React
+ * hidrata a página no navegador.
+ *
+ * Serve para desabilitar botões de submit até a página estar interativa: sem
+ * isso, um clique feito antes da hidratação dispara o submit NATIVO do
+ * formulário — o navegador recarrega a página (o que também faz o tema piscar
+ * de claro para escuro) e o login "não acontece" na primeira tentativa.
+ */
+export function useHydrated() {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return hydrated;
+}


### PR DESCRIPTION
Dois bugs reportados na tela de login (com print).

## 1. "Clico em Entrar, o tema pisca de claro pra escuro e não loga — só na 2ª tentativa"

**Causa:** o clique acontecia **antes do React hidratar**. Sem JS ativo, o navegador executava o **submit nativo** do `<form>` → recarregava a página (é exatamente esse reload que faz o tema "piscar", já que o tema só é aplicado no cliente) → nenhum login acontecia. Na segunda tentativa a página já estava hidratada e funcionava.

**Fix:** hook `useHydrated()` + botão `disabled` até a página estar interativa (login **e** cadastro). Confirmado: o HTML do SSR já vem com `disabled`.

> Observação: esse era o mesmo mecanismo do vazamento de senha na URL (PR #206). Lá impedimos o vazamento trocando o método para POST; aqui eliminamos a causa — o clique morto antes da hidratação.

## 2. Duas caixinhas ao lado de "Lembrar de mim"

**Causa:** além do botão visual, o Radix renderiza um `<input type="checkbox">` nativo (necessário para submit de formulário) escondido **apenas com `opacity:0` inline**. Em alguns navegadores/ajustes de acessibilidade ele aparece mesmo assim — daí as duas caixas.

**Fix:** esconder explicitamente via `sr-only` (`clip-path`), mantendo o input no DOM. Vale para todos os checkboxes do app (login, cadastro, etc).

**Bônus:** as classes `data-checked:*` do componente nunca aplicavam (o Radix usa `data-state="checked"`) — era CSS morto. Corrigidas, então o estado "marcado" agora pinta certo.

## Validação
- `docker build` (idêntico ao CI): **exit 0**
- **Container rodado localmente:** botão vem com `disabled` no HTML SSR e a regra `sr-only` do input nativo é gerada no CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)