### PR TITLE
fix(sec): CSP com script-src 'self' — destrava o JavaScript em produção

### DIFF
--- a/front-end/proxy.ts
+++ b/front-end/proxy.ts
@@ -11,7 +11,13 @@ export function proxy(request: NextRequest) {
   // abre WebSocket pra hot reload. CSP estrito com nonce bloqueia esses
   // scripts e quebra interações (submit do form de login, por exemplo).
   // Por isso afrouxamos script-src e connect-src só em dev.
-  // Em prod, mantemos nonce + strict-dynamic + connect-src restrito.
+  // Em prod usávamos nonce + strict-dynamic, MAS o Next 16 não estava
+  // carimbando o nonce nas tags <script> que ele injeta: o HTML saía com 23
+  // scripts sem nonce e o navegador bloqueava TODOS — a página nunca
+  // hidratava (nada clicável, tema não aplicava, login não funcionava).
+  // Trocamos por 'self' + 'unsafe-inline': continua restrito ao próprio
+  // domínio (nada de script de terceiros), mas permite os inline do Next.
+  // TODO: voltar para nonce quando a propagação no Next 16 for resolvida.
   const cspHeader = isDev
     ? `
       default-src 'self';
@@ -27,8 +33,8 @@ export function proxy(request: NextRequest) {
     `
     : `
       default-src 'self';
-      script-src 'nonce-${nonce}' 'strict-dynamic';
-      style-src 'self' https://fonts.googleapis.com;
+      script-src 'self' 'unsafe-inline';
+      style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
       img-src 'self' data:;
       font-src 'self' https://fonts.gstatic.com https://fonts.googleapis.com;
       connect-src 'self';


### PR DESCRIPTION
## O problema

A CSP de produção usa `script-src 'nonce-<valor>' 'strict-dynamic'`, mas **o Next 16 não está carimbando o nonce** nas tags `<script>` que injeta. O HTML sai com **23 scripts sem nonce** → o navegador **bloqueia todos** → a página nunca hidrata.

Sintomas relatados e confirmados: nada clicável (checkbox), tema não aplica (abre claro com o sistema no escuro), login só funciona via recarregamento.

## A mudança

```diff
- script-src 'nonce-${nonce}' 'strict-dynamic';
+ script-src 'self' 'unsafe-inline';
- style-src 'self' https://fonts.googleapis.com;
+ style-src 'self' https://fonts.googleapis.com 'unsafe-inline';
```

## ⚖️ Trade-off (explícito — decisão do time)

| | Antes (nonce) | Depois ('self') |
|---|---|---|
| Script de terceiros/CDN | ❌ bloqueado | ❌ bloqueado |
| Script inline injetado por XSS | ❌ bloqueado | ⚠️ **permitido** |
| **JavaScript da aplicação funciona** | ❌ **não** | ✅ **sim** |

Perdemos a camada extra contra XSS *inline* — mas a CSP anterior, na prática, não protegia: **ela quebrava o app inteiro**. Segue bloqueando qualquer script fora do domínio.

`TODO` deixado no código para voltar ao nonce quando a propagação no Next 16 for resolvida.

## Validação
- `docker build` exit 0
- **Container local em modo produção:** CSP servida é a nova, e os 23 scripts (16 externos + 7 inline) são **todos do próprio domínio** — cobertura 100%, zero de terceiros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)