### PR TITLE
feat(poker): implementa o backend do Poker Planning (corrige 'Cannot POST')

### DIFF
--- a/back-end/prisma/migrations/20260725144827_add_poker_planning/migration.sql
+++ b/back-end/prisma/migrations/20260725144827_add_poker_planning/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "public"."PokerSession" (
+    "id" TEXT NOT NULL,
+    "boardId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PokerSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PokerSessionTask" (
+    "sessionId" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PokerSessionTask_pkey" PRIMARY KEY ("sessionId","taskId")
+);
+
+-- CreateIndex
+CREATE INDEX "PokerSession_boardId_idx" ON "public"."PokerSession"("boardId");
+
+-- CreateIndex
+CREATE INDEX "PokerSession_createdById_idx" ON "public"."PokerSession"("createdById");
+
+-- CreateIndex
+CREATE INDEX "PokerSessionTask_taskId_idx" ON "public"."PokerSessionTask"("taskId");
+
+-- AddForeignKey
+ALTER TABLE "public"."PokerSession" ADD CONSTRAINT "PokerSession_boardId_fkey" FOREIGN KEY ("boardId") REFERENCES "public"."Board"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PokerSession" ADD CONSTRAINT "PokerSession_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PokerSessionTask" ADD CONSTRAINT "PokerSessionTask_sessionId_fkey" FOREIGN KEY ("sessionId") REFERENCES "public"."PokerSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PokerSessionTask" ADD CONSTRAINT "PokerSessionTask_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "public"."Task"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   notifications       Notification[]
   sentInvites         Invite[]       @relation("Sender")
   ownedSprints        Sprint[]       @relation("OwnerSprints")
+  createdPokerSessions PokerSession[] @relation("CreatedPokerSessions")
 
   @@unique([authProvider, providerId], name: "AuthProviderAndIdUnique")
 }
@@ -52,6 +53,35 @@ model Board {
   sprints     Sprint[]
   taskLogs    TaskLog[]
   invites     Invite[]
+  pokerSessions PokerSession[]
+}
+
+/// Sessão de Poker Planning: um conjunto de tasks de um board selecionadas
+/// para estimativa em equipe. As tasks ficam em PokerSessionTask (relação
+/// explícita) para garantir integridade — task apagada some da sessão.
+model PokerSession {
+  id        String             @id @default(uuid())
+  boardId   String
+  createdById String
+  board     Board              @relation(fields: [boardId], references: [id], onDelete: Cascade)
+  createdBy User               @relation("CreatedPokerSessions", fields: [createdById], references: [id])
+  tasks     PokerSessionTask[]
+  createdAt DateTime           @default(now())
+  updatedAt DateTime           @updatedAt
+
+  @@index([boardId])
+  @@index([createdById])
+}
+
+model PokerSessionTask {
+  sessionId String
+  taskId    String
+  session   PokerSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  task      Task         @relation(fields: [taskId], references: [id], onDelete: Cascade)
+  createdAt DateTime     @default(now())
+
+  @@id([sessionId, taskId])
+  @@index([taskId])
 }
 
 model Sprint {
@@ -136,6 +166,7 @@ model Task {
   labels      TaskLabel[]
   logs        TaskLog[]
   comments    TaskComment[]
+  pokerSessions PokerSessionTask[]
 
   @@index([sprintId])
 }

--- a/back-end/src/app.module.ts
+++ b/back-end/src/app.module.ts
@@ -6,6 +6,7 @@ import { AuthModule } from '@/auth/auth.module';
 import { BoardModule } from '@/board/board.module';
 import { BoardMemberModule } from '@/board-member/board-member.module';
 import { LabelModule } from '@/label/label.module';
+import { PokerModule } from '@/poker/poker.module';
 import { SprintModule } from '@/sprint/sprint.module';
 import { TaskCommentModule } from '@/task-comment/task-comment.module';
 import { EventsModule } from '@/events/events.module';
@@ -34,6 +35,7 @@ import { TaskLogModule } from '@/task-log/task-log.module';
     BoardMemberModule,
     LabelModule,
     SprintModule,
+    PokerModule,
     TaskCommentModule,
     HealthModule,
     AnalysisModule,

--- a/back-end/src/poker/dto/create-poker-session.dto.ts
+++ b/back-end/src/poker/dto/create-poker-session.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, ArrayNotEmpty, IsArray, IsString } from 'class-validator';
+
+export class CreatePokerSessionDto {
+  @ApiProperty({
+    example: ['1234567890abcdef12345678'],
+    description: 'IDs das tasks que entram na sessão de estimativa',
+    type: [String],
+  })
+  @IsArray({ message: 'taskIds deve ser uma lista' })
+  @ArrayNotEmpty({ message: 'Selecione ao menos uma task' })
+  @ArrayMaxSize(50, { message: 'No máximo 50 tasks por sessão' })
+  @IsString({ each: true, message: 'Cada taskId deve ser uma string' })
+  taskIds!: string[];
+}

--- a/back-end/src/poker/poker.controller.ts
+++ b/back-end/src/poker/poker.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  ApiCookieAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '@/auth/guards/jwt.guard';
+import { CurrentUser } from '@/auth/strategy/decorators/current-user.decorator';
+import { AuthenticatedUser } from '@/types/user.interface';
+
+import { CreatePokerSessionDto } from './dto/create-poker-session.dto';
+import { PokerService } from './poker.service';
+
+@ApiCookieAuth()
+@ApiTags('Poker Planning')
+@UseGuards(JwtAuthGuard)
+@Controller({ version: '1' })
+export class PokerController {
+  constructor(private readonly pokerService: PokerService) {}
+
+  @ApiOperation({ summary: 'Cria uma sessão de Poker Planning no board' })
+  @ApiResponse({ status: 201, description: 'Sessão criada' })
+  @ApiResponse({ status: 400, description: 'Task inválida para este board' })
+  @ApiResponse({ status: 403, description: 'Sem acesso ao board' })
+  @Post('boards/:boardId/poker-sessions')
+  create(
+    @Param('boardId') boardId: string,
+    @Body() dto: CreatePokerSessionDto,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.pokerService.create(boardId, user.id, dto);
+  }
+
+  @ApiOperation({ summary: 'Retorna uma sessão de Poker Planning' })
+  @ApiResponse({ status: 200, description: 'Sessão encontrada' })
+  @ApiResponse({ status: 404, description: 'Sessão não encontrada' })
+  @Get('boards/:boardId/poker-sessions/:sessionId')
+  findOne(
+    @Param('boardId') boardId: string,
+    @Param('sessionId') sessionId: string,
+    @CurrentUser() user: AuthenticatedUser,
+  ) {
+    return this.pokerService.findOne(boardId, sessionId, user.id);
+  }
+}

--- a/back-end/src/poker/poker.module.ts
+++ b/back-end/src/poker/poker.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '@/prisma/prisma.module';
+
+import { PokerController } from './poker.controller';
+import { PokerService } from './poker.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PokerController],
+  providers: [PokerService],
+})
+export class PokerModule {}

--- a/back-end/src/poker/poker.service.ts
+++ b/back-end/src/poker/poker.service.ts
@@ -1,0 +1,109 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { PrismaService } from '@/prisma/prisma.service';
+
+import { CreatePokerSessionDto } from './dto/create-poker-session.dto';
+
+/** Formato devolvido ao front (lib/actions/poker.ts espera taskIds achatado). */
+export interface PokerSessionResponse {
+  id: string;
+  boardId: string;
+  taskIds: string[];
+  createdAt: Date;
+}
+
+@Injectable()
+export class PokerService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Garante que o usuário participa do board (dono ou membro).
+   * Poker Planning é atividade de equipe: qualquer membro pode abrir e ver
+   * uma sessão — diferente de sprint, que exige admin.
+   */
+  private async assertBoardMember(boardId: string, userId: string) {
+    const board = await this.prisma.board.findUnique({
+      where: { id: boardId },
+      include: { members: { where: { userId } } },
+    });
+    if (!board) throw new NotFoundException('Board não encontrado');
+    const isOwner = board.ownerId === userId;
+    const isMember = board.members.length > 0;
+    if (!isOwner && !isMember) {
+      throw new ForbiddenException('Você não tem acesso a este board');
+    }
+    return board;
+  }
+
+  async create(
+    boardId: string,
+    userId: string,
+    dto: CreatePokerSessionDto,
+  ): Promise<PokerSessionResponse> {
+    await this.assertBoardMember(boardId, userId);
+
+    // Só aceita tasks que pertencem a ESTE board (via list) e não foram
+    // apagadas — evita montar sessão com task de outro board.
+    const tasks = await this.prisma.task.findMany({
+      where: {
+        id: { in: dto.taskIds },
+        deletedAt: null,
+        list: { boardId },
+      },
+      select: { id: true },
+    });
+
+    if (tasks.length !== dto.taskIds.length) {
+      throw new BadRequestException(
+        'Uma ou mais tasks não pertencem a este board ou não existem',
+      );
+    }
+
+    const session = await this.prisma.pokerSession.create({
+      data: {
+        boardId,
+        createdById: userId,
+        tasks: { create: tasks.map((t) => ({ taskId: t.id })) },
+      },
+      include: { tasks: { select: { taskId: true } } },
+    });
+
+    return {
+      id: session.id,
+      boardId: session.boardId,
+      taskIds: session.tasks.map((t) => t.taskId),
+      createdAt: session.createdAt,
+    };
+  }
+
+  async findOne(
+    boardId: string,
+    sessionId: string,
+    userId: string,
+  ): Promise<PokerSessionResponse> {
+    await this.assertBoardMember(boardId, userId);
+
+    const session = await this.prisma.pokerSession.findUnique({
+      where: { id: sessionId },
+      include: { tasks: { select: { taskId: true } } },
+    });
+
+    // Checa o board da sessão: impede ler sessão de outro board passando um
+    // boardId ao qual o usuário tem acesso.
+    if (!session || session.boardId !== boardId) {
+      throw new NotFoundException('Sessão de Poker Planning não encontrada');
+    }
+
+    return {
+      id: session.id,
+      boardId: session.boardId,
+      taskIds: session.tasks.map((t) => t.taskId),
+      createdAt: session.createdAt,
+    };
+  }
+}


### PR DESCRIPTION
## O problema

Em produção, criar uma sessão de Poker Planning devolve:
```
Cannot POST /v1/boards/<id>/poker-sessions
```

**Causa:** o PR #180 mergeou a **interface** do Poker Planning (botão "Estimar com Poker Planning", modal de criar sessão e a tela `/dashboard/board/[id]/poker/[sessionId]`), mas **o backend nunca existiu na `main`** — sem módulo NestJS, sem modelo no Prisma, sem migration. A feature ficou meio entregue: botão visível chamando rota inexistente.

## O que este PR faz

Implementa exatamente o que o front já consome (`front-end/lib/actions/poker.ts`, sem tocar no front):

| Método | Rota | Body | Retorno |
|---|---|---|---|
| `POST` | `/v1/boards/:boardId/poker-sessions` | `{ taskIds }` | `{ id, boardId, taskIds, createdAt }` |
| `GET` | `/v1/boards/:boardId/poker-sessions/:sessionId` | — | idem |

### Modelagem
- **`PokerSession`** — `id`, `boardId`, `createdById`, timestamps
- **`PokerSessionTask`** — relação explícita sessão↔task com `onDelete: Cascade` nos dois lados (task apagada some da sessão; board apagado leva as sessões junto). Preferi isso a um array solto de IDs, que não teria integridade referencial.
- **Migration só CRIA tabelas** — não altera nem migra dado existente, então é segura para produção.

### Regras de acesso
- Acesso por **membro** do board (dono ou membro) — poker é atividade de equipe, diferente de sprint que exige admin.
- Só aceita tasks que **pertencem ao board** (via list) e não deletadas → senão `400`.
- O `GET` confere o `boardId` da sessão, impedindo ler sessão de outro board.
- Limite de 50 tasks por sessão.

## Validação (executada, não presumida)

- `prisma validate` ✅ · `migrate diff` **sem drift** ✅ · `tsc --noEmit` **0 erros** ✅
- **Teste funcional ponta a ponta** com backend real + Postgres:

| Caso | Resultado |
|---|---|
| Criar sessão com 2 tasks | **201** com o formato exato que o front espera |
| Buscar a sessão | **200** |
| Task que não é do board | **400** com mensagem clara |
| Sem sessão de login | **401** |

## Pós-merge
O deploy roda `prisma migrate deploy` automaticamente, criando as tabelas em produção. Depois disso o botão "Estimar com Poker Planning" passa a funcionar.

> Escopo: a tela atual apenas lista as tarefas da sessão. **Votação/estimativa em tempo real não faz parte deste PR** — a interface ainda não tem essa parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)